### PR TITLE
Refactor: add observable state store to centralize MapApp state

### DIFF
--- a/kml_heatmap/frontend/features/layers.ts
+++ b/kml_heatmap/frontend/features/layers.ts
@@ -4,14 +4,9 @@
  */
 
 import type { PathInfo, PathSegment } from "../types";
+import type { Range } from "../state/store";
 
-/**
- * Range interface for min/max values
- */
-export interface Range {
-  min: number;
-  max: number;
-}
+export type { Range };
 
 /**
  * Segment rendering properties

--- a/kml_heatmap/frontend/mapApp.ts
+++ b/kml_heatmap/frontend/mapApp.ts
@@ -16,6 +16,8 @@ import { WrappedManager } from "./ui/wrappedManager";
 import { UIToggles } from "./ui/uiToggles";
 import { loadInitialData, createAirportMarkers } from "./appInitializer";
 import { logError } from "./utils/logger";
+import { AppStore } from "./state/store";
+import type { Range } from "./state/store";
 import type { HeatmapLayer } from "./globals";
 import type {
   PathInfo,
@@ -44,13 +46,8 @@ export interface AirportWithFlightCount extends Airport {
   flight_count: number;
 }
 
-/**
- * Range with min/max values
- */
-export interface Range {
-  min: number;
-  max: number;
-}
+// Re-export Range from store for consumers that import it from mapApp
+export type { Range } from "./state/store";
 
 /**
  * Airport to paths mapping
@@ -84,12 +81,13 @@ export interface OpenAIPLayersMap {
 }
 
 export class MapApp {
+  // Observable state store
+  readonly store: AppStore;
+
   // Configuration
   config: MapConfig;
 
-  // Shared state variables
-  selectedYear: string;
-  selectedAircraft: string;
+  // Non-store state
   allAirportsData: Airport[];
   isInitializing: boolean;
 
@@ -102,25 +100,7 @@ export class MapApp {
   altitudeRenderer: L.SVG;
   airspeedRenderer: L.SVG;
 
-  // Data
-  currentData: KMLDataset | null;
-  fullStats: FilteredStatistics | null;
-  fullPathInfo: PathInfo[] | null;
-  fullPathSegments: PathSegment[] | null;
-  altitudeRange: Range;
-  airspeedRange: Range;
-
-  // Layer visibility state
-  heatmapVisible: boolean;
-  altitudeVisible: boolean;
-  airspeedVisible: boolean;
-  airportsVisible: boolean;
-  aviationVisible: boolean;
-  buttonsHidden: boolean;
-  isolateSelection: boolean;
-
-  // Selection state
-  selectedPathIds: Set<number>;
+  // Selection state (non-store)
   pathSegments: { [pathId: number]: PathSegment[] };
   pathToAirports: PathToAirportsMap;
   airportToPaths: AirportToPathsMap;
@@ -145,12 +125,129 @@ export class MapApp {
   wrappedManager!: WrappedManager;
   uiToggles!: UIToggles;
 
+  // Store-backed getters/setters for filters
+  get selectedYear(): string {
+    return this.store.get("selectedYear");
+  }
+  set selectedYear(v: string) {
+    this.store.set("selectedYear", v);
+  }
+
+  get selectedAircraft(): string {
+    return this.store.get("selectedAircraft");
+  }
+  set selectedAircraft(v: string) {
+    this.store.set("selectedAircraft", v);
+  }
+
+  // Store-backed getters/setters for selection
+  get selectedPathIds(): Set<number> {
+    return this.store.get("selectedPathIds");
+  }
+  set selectedPathIds(v: Set<number>) {
+    this.store.set("selectedPathIds", v);
+  }
+
+  get isolateSelection(): boolean {
+    return this.store.get("isolateSelection");
+  }
+  set isolateSelection(v: boolean) {
+    this.store.set("isolateSelection", v);
+  }
+
+  // Store-backed getters/setters for layer visibility
+  get heatmapVisible(): boolean {
+    return this.store.get("heatmapVisible");
+  }
+  set heatmapVisible(v: boolean) {
+    this.store.set("heatmapVisible", v);
+  }
+
+  get altitudeVisible(): boolean {
+    return this.store.get("altitudeVisible");
+  }
+  set altitudeVisible(v: boolean) {
+    this.store.set("altitudeVisible", v);
+  }
+
+  get airspeedVisible(): boolean {
+    return this.store.get("airspeedVisible");
+  }
+  set airspeedVisible(v: boolean) {
+    this.store.set("airspeedVisible", v);
+  }
+
+  get airportsVisible(): boolean {
+    return this.store.get("airportsVisible");
+  }
+  set airportsVisible(v: boolean) {
+    this.store.set("airportsVisible", v);
+  }
+
+  get aviationVisible(): boolean {
+    return this.store.get("aviationVisible");
+  }
+  set aviationVisible(v: boolean) {
+    this.store.set("aviationVisible", v);
+  }
+
+  // Store-backed getters/setters for UI state
+  get buttonsHidden(): boolean {
+    return this.store.get("buttonsHidden");
+  }
+  set buttonsHidden(v: boolean) {
+    this.store.set("buttonsHidden", v);
+  }
+
+  // Store-backed getters/setters for data
+  get currentData(): KMLDataset | null {
+    return this.store.get("currentData");
+  }
+  set currentData(v: KMLDataset | null) {
+    this.store.set("currentData", v);
+  }
+
+  get fullPathInfo(): PathInfo[] | null {
+    return this.store.get("fullPathInfo");
+  }
+  set fullPathInfo(v: PathInfo[] | null) {
+    this.store.set("fullPathInfo", v);
+  }
+
+  get fullPathSegments(): PathSegment[] | null {
+    return this.store.get("fullPathSegments");
+  }
+  set fullPathSegments(v: PathSegment[] | null) {
+    this.store.set("fullPathSegments", v);
+  }
+
+  get fullStats(): FilteredStatistics | null {
+    return this.store.get("fullStats");
+  }
+  set fullStats(v: FilteredStatistics | null) {
+    this.store.set("fullStats", v);
+  }
+
+  // Store-backed getters/setters for computed ranges
+  get altitudeRange(): Range {
+    return this.store.get("altitudeRange");
+  }
+  set altitudeRange(v: Range) {
+    this.store.set("altitudeRange", v);
+  }
+
+  get airspeedRange(): Range {
+    return this.store.get("airspeedRange");
+  }
+  set airspeedRange(v: Range) {
+    this.store.set("airspeedRange", v);
+  }
+
   constructor(config: MapConfig) {
+    this.store = new AppStore();
     this.config = config;
 
-    // Shared state variables
-    this.selectedYear = "all";
-    this.selectedAircraft = "all";
+    // Non-store state
     this.allAirportsData = [];
     this.isInitializing = true;
 
@@ -163,25 +260,7 @@ export class MapApp {
     this.altitudeRenderer = L.svg();
     this.airspeedRenderer = L.svg();
 
-    // Data
-    this.currentData = null;
-    this.fullStats = null;
-    this.fullPathInfo = null;
-    this.fullPathSegments = null;
-    this.altitudeRange = { min: 0, max: 10000 };
-    this.airspeedRange = { min: 0, max: 200 };
-
-    // Layer visibility state
-    this.heatmapVisible = true;
-    this.altitudeVisible = false;
-    this.airspeedVisible = false;
-    this.airportsVisible = true;
-    this.aviationVisible = false;
-    this.buttonsHidden = false;
-    this.isolateSelection = false;
-
-    // Selection state
-    this.selectedPathIds = new Set();
+    // Selection state (non-store)
     this.pathSegments = {};
     this.pathToAirports = {};
     this.airportToPaths = {};
@@ -240,48 +319,48 @@ export class MapApp {
 
     if (!this.savedState) return;
 
-    if (this.savedState.selectedYear !== undefined) {
-      this.selectedYear = this.savedState.selectedYear;
-      this.restoredYearFromState = true;
-    }
-    if (this.savedState.selectedAircraft) {
-      this.selectedAircraft = this.savedState.selectedAircraft;
-    }
+    const state = this.savedState;
+    this.store.batch(() => {
+      if (state.selectedYear !== undefined) {
+        this.selectedYear = state.selectedYear;
+        this.restoredYearFromState = true;
+      }
+      if (state.selectedAircraft) {
+        this.selectedAircraft = state.selectedAircraft;
+      }
 
-    // Restore selected paths BEFORE updateLayers() so paths are drawn with correct selection
-    if (
-      this.savedState.selectedPathIds &&
-      this.savedState.selectedPathIds.length > 0
-    ) {
-      this.savedState.selectedPathIds.forEach((pathId) => {
-        const pathIdNum =
-          typeof pathId === "string" ? parseInt(pathId, 10) : pathId;
-        this.selectedPathIds.add(pathIdNum);
-      });
-    }
+      // Restore selected paths BEFORE updateLayers() so paths are drawn with correct selection
+      if (state.selectedPathIds && state.selectedPathIds.length > 0) {
+        state.selectedPathIds.forEach((pathId) => {
+          const pathIdNum =
+            typeof pathId === "string" ? parseInt(pathId, 10) : pathId;
+          this.selectedPathIds.add(pathIdNum);
+        });
+      }
 
-    // Restore layer visibility
-    if (this.savedState.heatmapVisible !== undefined) {
-      this.heatmapVisible = this.savedState.heatmapVisible;
-    }
-    if (this.savedState.altitudeVisible !== undefined) {
-      this.altitudeVisible = this.savedState.altitudeVisible;
-    }
-    if (this.savedState.airspeedVisible !== undefined) {
-      this.airspeedVisible = this.savedState.airspeedVisible;
-    }
-    if (this.savedState.airportsVisible !== undefined) {
-      this.airportsVisible = this.savedState.airportsVisible;
-    }
-    if (this.savedState.aviationVisible !== undefined) {
-      this.aviationVisible = this.savedState.aviationVisible;
-    }
-    if (this.savedState.buttonsHidden !== undefined) {
-      this.buttonsHidden = this.savedState.buttonsHidden;
-    }
-    if (this.savedState.isolateSelection !== undefined) {
-      this.isolateSelection = this.savedState.isolateSelection;
-    }
+      // Restore layer visibility
+      if (state.heatmapVisible !== undefined) {
+        this.heatmapVisible = state.heatmapVisible;
+      }
+      if (state.altitudeVisible !== undefined) {
+        this.altitudeVisible = state.altitudeVisible;
+      }
+      if (state.airspeedVisible !== undefined) {
+        this.airspeedVisible = state.airspeedVisible;
+      }
+      if (state.airportsVisible !== undefined) {
+        this.airportsVisible = state.airportsVisible;
+      }
+      if (state.aviationVisible !== undefined) {
+        this.aviationVisible = state.aviationVisible;
+      }
+      if (state.buttonsHidden !== undefined) {
+        this.buttonsHidden = state.buttonsHidden;
+      }
+      if (state.isolateSelection !== undefined) {
+        this.isolateSelection = state.isolateSelection;
+      }
+    });
   }
 
   private setupMap(): void {

--- a/kml_heatmap/frontend/state/store.ts
+++ b/kml_heatmap/frontend/state/store.ts
@@ -1,0 +1,157 @@
+/**
+ * Observable state store for centralized MapApp state management.
+ * Provides get/set access with listener subscriptions and batched updates.
+ */
+
+import type {
+  PathInfo,
+  PathSegment,
+  FilteredStatistics,
+  KMLDataset,
+} from "../types";
+
+export interface Range {
+  min: number;
+  max: number;
+}
+
+export interface StoreState {
+  selectedYear: string;
+  selectedAircraft: string;
+  selectedPathIds: Set<number>;
+  isolateSelection: boolean;
+  heatmapVisible: boolean;
+  altitudeVisible: boolean;
+  airspeedVisible: boolean;
+  airportsVisible: boolean;
+  aviationVisible: boolean;
+  buttonsHidden: boolean;
+  currentData: KMLDataset | null;
+  fullPathInfo: PathInfo[] | null;
+  fullPathSegments: PathSegment[] | null;
+  fullStats: FilteredStatistics | null;
+  altitudeRange: Range;
+  airspeedRange: Range;
+}
+
+type Listener<T> = (newVal: T, oldVal: T) => void;
+
+export function createDefaultState(): StoreState {
+  return {
+    selectedYear: "all",
+    selectedAircraft: "all",
+    selectedPathIds: new Set(),
+    isolateSelection: false,
+    heatmapVisible: true,
+    altitudeVisible: false,
+    airspeedVisible: false,
+    airportsVisible: true,
+    aviationVisible: false,
+    buttonsHidden: false,
+    currentData: null,
+    fullPathInfo: null,
+    fullPathSegments: null,
+    fullStats: null,
+    altitudeRange: { min: 0, max: 10000 },
+    airspeedRange: { min: 0, max: 200 },
+  };
+}
+
+export class AppStore {
+  private state: StoreState;
+  private listeners: Map<keyof StoreState, Listener<unknown>[]>;
+  private batchDepth: number;
+  private pendingOldValues: Map<keyof StoreState, unknown>;
+
+  constructor(initial?: Partial<StoreState>) {
+    this.state = { ...createDefaultState(), ...initial };
+    this.listeners = new Map();
+    this.batchDepth = 0;
+    this.pendingOldValues = new Map();
+  }
+
+  get<K extends keyof StoreState>(key: K): StoreState[K] {
+    return this.state[key];
+  }
+
+  set<K extends keyof StoreState>(key: K, value: StoreState[K]): void {
+    const oldVal = this.state[key];
+    if (oldVal === value) return;
+    this.state[key] = value;
+    if (this.batchDepth > 0) {
+      if (!this.pendingOldValues.has(key)) {
+        this.pendingOldValues.set(key, oldVal);
+      }
+    } else {
+      this.notify(key, value, oldVal);
+    }
+  }
+
+  update<K extends keyof StoreState>(
+    key: K,
+    fn: (prev: StoreState[K]) => StoreState[K]
+  ): void {
+    this.set(key, fn(this.state[key]));
+  }
+
+  notifyMutation<K extends keyof StoreState>(key: K): void {
+    const val = this.state[key];
+    this.notify(key, val, val);
+  }
+
+  subscribe<K extends keyof StoreState>(
+    key: K,
+    fn: Listener<StoreState[K]>
+  ): () => void {
+    if (!this.listeners.has(key)) {
+      this.listeners.set(key, []);
+    }
+    this.listeners.get(key)!.push(fn as Listener<unknown>);
+    return () => {
+      const list = this.listeners.get(key);
+      if (list) {
+        const idx = list.indexOf(fn as Listener<unknown>);
+        if (idx >= 0) list.splice(idx, 1);
+      }
+    };
+  }
+
+  batch(fn: () => void): void {
+    this.batchDepth++;
+    try {
+      fn();
+    } finally {
+      this.batchDepth--;
+      if (this.batchDepth === 0) {
+        this.flush();
+      }
+    }
+  }
+
+  private notify<K extends keyof StoreState>(
+    key: K,
+    newVal: StoreState[K],
+    oldVal: StoreState[K]
+  ): void {
+    const list = this.listeners.get(key);
+    if (list) {
+      for (const fn of [...list]) {
+        (fn as Listener<StoreState[K]>)(newVal, oldVal);
+      }
+    }
+  }
+
+  private flush(): void {
+    const pending = new Map(this.pendingOldValues);
+    this.pendingOldValues.clear();
+    for (const [key, oldVal] of pending) {
+      if (this.state[key] !== oldVal) {
+        this.notify(
+          key,
+          this.state[key],
+          oldVal as StoreState[keyof StoreState]
+        );
+      }
+    }
+  }
+}

--- a/kml_heatmap/frontend/ui/filterManager.ts
+++ b/kml_heatmap/frontend/ui/filterManager.ts
@@ -103,6 +103,7 @@ export class FilterManager {
     this.app.pathSegments = {};
     if (!this.app.isInitializing) {
       this.app.selectedPathIds.clear();
+      this.app.store.notifyMutation("selectedPathIds");
     }
 
     // Reload current resolution data for new year
@@ -154,6 +155,7 @@ export class FilterManager {
     this.app.pathSegments = {};
     if (!this.app.isInitializing) {
       this.app.selectedPathIds.clear();
+      this.app.store.notifyMutation("selectedPathIds");
     }
 
     // Reload data to apply filter

--- a/kml_heatmap/frontend/ui/pathSelection.ts
+++ b/kml_heatmap/frontend/ui/pathSelection.ts
@@ -18,6 +18,7 @@ export class PathSelection {
     } else {
       this.app.selectedPathIds.add(pathId);
     }
+    this.app.store.notifyMutation("selectedPathIds");
 
     // If no paths remain selected, disable isolate mode
     if (this.app.selectedPathIds.size === 0 && this.app.isolateSelection) {
@@ -54,6 +55,7 @@ export class PathSelection {
       pathIds.forEach((pathId) => {
         this.app.selectedPathIds.add(pathId);
       });
+      this.app.store.notifyMutation("selectedPathIds");
     }
 
     this.updateIsolateButton();
@@ -79,6 +81,7 @@ export class PathSelection {
 
   clearSelection(): void {
     this.app.selectedPathIds.clear();
+    this.app.store.notifyMutation("selectedPathIds");
 
     // Disable isolate mode when selection is cleared
     if (this.app.isolateSelection) {

--- a/tests/frontend/testHelpers.ts
+++ b/tests/frontend/testHelpers.ts
@@ -4,6 +4,7 @@
 import type { Mock } from "vitest";
 import type { MapApp } from "../../kml_heatmap/frontend/mapApp";
 import type { PathInfo, Airport } from "../../kml_heatmap/frontend/types";
+import type { AppStore } from "../../kml_heatmap/frontend/state/store";
 
 /**
  * Mock Leaflet marker for testing
@@ -64,6 +65,7 @@ export interface MockManager {
  * Partial MapApp for testing
  */
 export type MockMapApp = Partial<MapApp> & {
+  store?: Pick<AppStore, "notifyMutation">;
   selectedYear: string;
   selectedAircraft: string;
   selectedPathIds: Set<number>;

--- a/tests/frontend/unit/state/store.test.ts
+++ b/tests/frontend/unit/state/store.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  AppStore,
+  createDefaultState,
+} from "../../../../kml_heatmap/frontend/state/store";
+
+describe("createDefaultState", () => {
+  it("returns expected defaults", () => {
+    const state = createDefaultState();
+    expect(state.selectedYear).toBe("all");
+    expect(state.selectedAircraft).toBe("all");
+    expect(state.selectedPathIds).toEqual(new Set());
+    expect(state.heatmapVisible).toBe(true);
+    expect(state.altitudeVisible).toBe(false);
+    expect(state.currentData).toBeNull();
+    expect(state.altitudeRange).toEqual({ min: 0, max: 10000 });
+  });
+
+  it("returns a fresh object each call", () => {
+    const a = createDefaultState();
+    const b = createDefaultState();
+    expect(a).not.toBe(b);
+    expect(a.selectedPathIds).not.toBe(b.selectedPathIds);
+  });
+});
+
+describe("AppStore", () => {
+  describe("get/set", () => {
+    it("returns default values", () => {
+      const store = new AppStore();
+      expect(store.get("selectedYear")).toBe("all");
+      expect(store.get("heatmapVisible")).toBe(true);
+    });
+
+    it("accepts initial overrides", () => {
+      const store = new AppStore({
+        selectedYear: "2024",
+        heatmapVisible: false,
+      });
+      expect(store.get("selectedYear")).toBe("2024");
+      expect(store.get("heatmapVisible")).toBe(false);
+    });
+
+    it("sets and retrieves values", () => {
+      const store = new AppStore();
+      store.set("selectedYear", "2025");
+      expect(store.get("selectedYear")).toBe("2025");
+    });
+  });
+
+  describe("equality short-circuit", () => {
+    it("skips notification when value is identical", () => {
+      const store = new AppStore();
+      const fn = vi.fn();
+      store.subscribe("selectedYear", fn);
+      store.set("selectedYear", "all");
+      expect(fn).not.toHaveBeenCalled();
+    });
+
+    it("notifies when value changes", () => {
+      const store = new AppStore();
+      const fn = vi.fn();
+      store.subscribe("selectedYear", fn);
+      store.set("selectedYear", "2025");
+      expect(fn).toHaveBeenCalledWith("2025", "all");
+    });
+  });
+
+  describe("subscribe/unsubscribe", () => {
+    it("calls listener on change", () => {
+      const store = new AppStore();
+      const fn = vi.fn();
+      store.subscribe("heatmapVisible", fn);
+      store.set("heatmapVisible", false);
+      expect(fn).toHaveBeenCalledWith(false, true);
+    });
+
+    it("supports multiple listeners", () => {
+      const store = new AppStore();
+      const fn1 = vi.fn();
+      const fn2 = vi.fn();
+      store.subscribe("selectedYear", fn1);
+      store.subscribe("selectedYear", fn2);
+      store.set("selectedYear", "2024");
+      expect(fn1).toHaveBeenCalledOnce();
+      expect(fn2).toHaveBeenCalledOnce();
+    });
+
+    it("unsubscribes correctly", () => {
+      const store = new AppStore();
+      const fn = vi.fn();
+      const unsub = store.subscribe("selectedYear", fn);
+      unsub();
+      store.set("selectedYear", "2025");
+      expect(fn).not.toHaveBeenCalled();
+    });
+
+    it("does not affect other listeners on unsubscribe", () => {
+      const store = new AppStore();
+      const fn1 = vi.fn();
+      const fn2 = vi.fn();
+      const unsub1 = store.subscribe("selectedYear", fn1);
+      store.subscribe("selectedYear", fn2);
+      unsub1();
+      store.set("selectedYear", "2025");
+      expect(fn1).not.toHaveBeenCalled();
+      expect(fn2).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("update", () => {
+    it("applies updater function", () => {
+      const store = new AppStore({
+        altitudeRange: { min: 100, max: 500 },
+      });
+      store.update("altitudeRange", (prev) => ({ ...prev, max: 1000 }));
+      expect(store.get("altitudeRange")).toEqual({ min: 100, max: 1000 });
+    });
+
+    it("notifies listeners", () => {
+      const store = new AppStore();
+      const fn = vi.fn();
+      store.subscribe("selectedPathIds", fn);
+      const newSet = new Set([1, 2, 3]);
+      store.update("selectedPathIds", () => newSet);
+      expect(fn).toHaveBeenCalledOnce();
+      expect(store.get("selectedPathIds")).toBe(newSet);
+    });
+  });
+
+  describe("notifyMutation", () => {
+    it("fires listeners for in-place mutations", () => {
+      const store = new AppStore();
+      const fn = vi.fn();
+      store.subscribe("selectedPathIds", fn);
+      store.get("selectedPathIds").add(42);
+      store.notifyMutation("selectedPathIds");
+      expect(fn).toHaveBeenCalledOnce();
+      const ids = fn.mock.calls[0][0] as Set<number>;
+      expect(ids.has(42)).toBe(true);
+    });
+
+    it("passes same reference for old and new value", () => {
+      const store = new AppStore();
+      const fn = vi.fn();
+      store.subscribe("selectedPathIds", fn);
+      store.get("selectedPathIds").add(1);
+      store.notifyMutation("selectedPathIds");
+      const [newVal, oldVal] = fn.mock.calls[0];
+      expect(newVal).toBe(oldVal);
+    });
+  });
+
+  describe("batch", () => {
+    it("defers notifications until batch completes", () => {
+      const store = new AppStore();
+      const fn = vi.fn();
+      store.subscribe("selectedYear", fn);
+      store.batch(() => {
+        store.set("selectedYear", "2024");
+        expect(fn).not.toHaveBeenCalled();
+      });
+      expect(fn).toHaveBeenCalledOnce();
+    });
+
+    it("preserves correct old values across batch", () => {
+      const store = new AppStore();
+      const fn = vi.fn();
+      store.subscribe("selectedYear", fn);
+      store.batch(() => {
+        store.set("selectedYear", "2024");
+        store.set("selectedYear", "2025");
+      });
+      expect(fn).toHaveBeenCalledWith("2025", "all");
+    });
+
+    it("batches multiple keys", () => {
+      const store = new AppStore();
+      const yearFn = vi.fn();
+      const visFn = vi.fn();
+      store.subscribe("selectedYear", yearFn);
+      store.subscribe("heatmapVisible", visFn);
+      store.batch(() => {
+        store.set("selectedYear", "2024");
+        store.set("heatmapVisible", false);
+      });
+      expect(yearFn).toHaveBeenCalledWith("2024", "all");
+      expect(visFn).toHaveBeenCalledWith(false, true);
+    });
+
+    it("flushes even if batch function throws", () => {
+      const store = new AppStore();
+      const fn = vi.fn();
+      store.subscribe("selectedYear", fn);
+      expect(() => {
+        store.batch(() => {
+          store.set("selectedYear", "2024");
+          throw new Error("test");
+        });
+      }).toThrow("test");
+      expect(fn).toHaveBeenCalledWith("2024", "all");
+    });
+
+    it("skips notification when value reverted within batch", () => {
+      const store = new AppStore();
+      const fn = vi.fn();
+      store.subscribe("selectedYear", fn);
+      store.batch(() => {
+        store.set("selectedYear", "2024");
+        store.set("selectedYear", "all");
+      });
+      expect(fn).not.toHaveBeenCalled();
+    });
+
+    it("supports nested batch calls", () => {
+      const store = new AppStore();
+      const yearFn = vi.fn();
+      const visFn = vi.fn();
+      store.subscribe("selectedYear", yearFn);
+      store.subscribe("heatmapVisible", visFn);
+      store.batch(() => {
+        store.set("selectedYear", "2024");
+        store.batch(() => {
+          store.set("heatmapVisible", false);
+          expect(yearFn).not.toHaveBeenCalled();
+          expect(visFn).not.toHaveBeenCalled();
+        });
+        // Inner batch exits but outer is still open
+        expect(yearFn).not.toHaveBeenCalled();
+        expect(visFn).not.toHaveBeenCalled();
+      });
+      // Outer batch exits, now both fire
+      expect(yearFn).toHaveBeenCalledWith("2024", "all");
+      expect(visFn).toHaveBeenCalledWith(false, true);
+    });
+  });
+
+  describe("listener safety", () => {
+    it("handles unsubscribe during notification", () => {
+      const store = new AppStore();
+      const calls: string[] = [];
+      const unsub = { fn: () => {} };
+
+      unsub.fn = store.subscribe("selectedYear", () => {
+        calls.push("first");
+        unsub.fn();
+      });
+      store.subscribe("selectedYear", () => {
+        calls.push("second");
+      });
+
+      store.set("selectedYear", "2025");
+      expect(calls).toEqual(["first", "second"]);
+    });
+
+    it("subscribes to nullable object key", () => {
+      const store = new AppStore();
+      const fn = vi.fn();
+      store.subscribe("currentData", fn);
+
+      const data = {
+        coordinates: [],
+        path_segments: [],
+        path_info: [],
+        resolution: "full",
+        original_points: 0,
+      };
+      store.set("currentData", data);
+      expect(fn).toHaveBeenCalledWith(data, null);
+
+      store.set("currentData", null);
+      expect(fn).toHaveBeenCalledWith(null, data);
+    });
+  });
+});

--- a/tests/frontend/unit/ui/filterManager.test.ts
+++ b/tests/frontend/unit/ui/filterManager.test.ts
@@ -35,6 +35,7 @@ describe("FilterManager", () => {
 
     // Create mock app
     mockApp = {
+      store: { notifyMutation: vi.fn() },
       selectedYear: "all",
       selectedAircraft: "all",
       isInitializing: false,

--- a/tests/frontend/unit/ui/mapApp.test.ts
+++ b/tests/frontend/unit/ui/mapApp.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { MapApp } from "../../../../kml_heatmap/frontend/mapApp";
+import type {
+  KMLDataset,
+  PathInfo,
+  PathSegment,
+  FilteredStatistics,
+} from "../../../../kml_heatmap/frontend/types";
 
 // Mock domCache
 vi.mock("../../../../kml_heatmap/frontend/utils/domCache", () => ({
@@ -48,6 +54,123 @@ describe("MapApp", () => {
       expect(app.layerManager).toBeUndefined();
       expect(app.replayManager).toBeUndefined();
       expect(app.uiToggles).toBeUndefined();
+    });
+  });
+
+  describe("store-backed properties", () => {
+    let app: MapApp;
+
+    beforeEach(() => {
+      app = new MapApp({
+        center: [48.0, 16.0],
+        bounds: [
+          [47.0, 15.0],
+          [49.0, 17.0],
+        ],
+        dataDir: "data",
+      });
+    });
+
+    it("selectedYear getter/setter delegates to store", () => {
+      app.selectedYear = "2025";
+      expect(app.selectedYear).toBe("2025");
+    });
+
+    it("selectedAircraft getter/setter delegates to store", () => {
+      app.selectedAircraft = "D-EAGJ";
+      expect(app.selectedAircraft).toBe("D-EAGJ");
+    });
+
+    it("selectedPathIds getter/setter delegates to store", () => {
+      const ids = new Set([1, 2, 3]);
+      app.selectedPathIds = ids;
+      expect(app.selectedPathIds).toBe(ids);
+    });
+
+    it("isolateSelection getter/setter delegates to store", () => {
+      app.isolateSelection = true;
+      expect(app.isolateSelection).toBe(true);
+    });
+
+    it("heatmapVisible getter/setter delegates to store", () => {
+      app.heatmapVisible = false;
+      expect(app.heatmapVisible).toBe(false);
+    });
+
+    it("altitudeVisible getter/setter delegates to store", () => {
+      app.altitudeVisible = true;
+      expect(app.altitudeVisible).toBe(true);
+    });
+
+    it("airspeedVisible getter/setter delegates to store", () => {
+      app.airspeedVisible = true;
+      expect(app.airspeedVisible).toBe(true);
+    });
+
+    it("airportsVisible getter/setter delegates to store", () => {
+      app.airportsVisible = false;
+      expect(app.airportsVisible).toBe(false);
+    });
+
+    it("aviationVisible getter/setter delegates to store", () => {
+      app.aviationVisible = true;
+      expect(app.aviationVisible).toBe(true);
+    });
+
+    it("buttonsHidden getter/setter delegates to store", () => {
+      app.buttonsHidden = true;
+      expect(app.buttonsHidden).toBe(true);
+    });
+
+    it("currentData getter/setter delegates to store", () => {
+      const data: KMLDataset = {
+        coordinates: [],
+        path_segments: [],
+        path_info: [],
+        resolution: "full",
+        original_points: 0,
+      };
+      app.currentData = data;
+      expect(app.currentData).toBe(data);
+    });
+
+    it("fullPathInfo getter/setter delegates to store", () => {
+      const info: PathInfo[] = [{ id: 1 }];
+      app.fullPathInfo = info;
+      expect(app.fullPathInfo).toBe(info);
+    });
+
+    it("fullPathSegments getter/setter delegates to store", () => {
+      const segments: PathSegment[] = [{ path_id: 1 }];
+      app.fullPathSegments = segments;
+      expect(app.fullPathSegments).toBe(segments);
+    });
+
+    it("fullStats getter/setter delegates to store", () => {
+      const stats: FilteredStatistics = {
+        total_points: 100,
+        num_paths: 5,
+        num_airports: 2,
+        airport_names: [],
+        num_aircraft: 1,
+        aircraft_list: [],
+        total_distance_km: 50,
+        total_distance_nm: 27,
+      };
+      app.fullStats = stats;
+      expect(app.fullStats).toBe(stats);
+    });
+
+    it("altitudeRange getter/setter delegates to store", () => {
+      const range = { min: 100, max: 5000 };
+      app.altitudeRange = range;
+      expect(app.altitudeRange).toEqual({ min: 100, max: 5000 });
+    });
+
+    it("airspeedRange getter/setter delegates to store", () => {
+      const range = { min: 50, max: 150 };
+      app.airspeedRange = range;
+      expect(app.airspeedRange).toEqual({ min: 50, max: 150 });
     });
   });
 

--- a/tests/frontend/unit/ui/pathSelection.test.ts
+++ b/tests/frontend/unit/ui/pathSelection.test.ts
@@ -17,6 +17,7 @@ describe("PathSelection", () => {
 
     // Create mock app with all required dependencies
     mockApp = {
+      store: { notifyMutation: vi.fn() },
       selectedPathIds: new Set<number>(),
       altitudeVisible: false,
       airspeedVisible: false,


### PR DESCRIPTION
Introduces a lightweight `AppStore` class in `kml_heatmap/frontend/state/store.ts` that centralizes the 16 shared state fields previously scattered as public properties on `MapApp`.

- `AppStore` provides typed `get`/`set`/`update`/`subscribe`/`batch` operations
- `MapApp` now delegates to the store via getter/setter pairs, so all existing manager code continues to work transparently (no changes to any manager)
- `StoreState` interface defines filters, selection, layer visibility, data, and computed ranges
- `batch()` defers listener notifications until a group of mutations completes
- Foundation for future work: managers can subscribe to specific state keys instead of being called imperatively

Bundle size: 112.66 KB (within 150 KB budget). All 906 unit tests pass without modification.