### PR TITLE
Fix E2E localStorage race condition in state persistence tests

### DIFF
--- a/tests/e2e/state.spec.ts
+++ b/tests/e2e/state.spec.ts
@@ -95,9 +95,12 @@ test.describe("State Persistence", () => {
     test("state is restored on reload", async ({ page }) => {
       await page.locator("#heatmap-btn").click();
       await expect(page.locator("#heatmap-btn")).toHaveCSS("opacity", "0.5");
-      await page.waitForFunction(
-        () => localStorage.getItem("kml-heatmap-state") !== null
-      );
+      await page.waitForFunction(() => {
+        const state = JSON.parse(
+          localStorage.getItem("kml-heatmap-state") || "{}"
+        );
+        return state.heatmapVisible === false;
+      });
 
       await page.reload();
       await page.waitForSelector("#map.leaflet-container", { timeout: 15000 });
@@ -277,9 +280,12 @@ test.describe("State Persistence", () => {
       page,
     }) => {
       await page.locator("#heatmap-btn").click();
-      await page.waitForFunction(
-        () => localStorage.getItem("kml-heatmap-state") !== null
-      );
+      await page.waitForFunction(() => {
+        const state = JSON.parse(
+          localStorage.getItem("kml-heatmap-state") || "{}"
+        );
+        return state.heatmapVisible === false;
+      });
 
       await page.goto("/");
       await page.waitForSelector("#map.leaflet-container", { timeout: 15000 });


### PR DESCRIPTION
The `scheduleSave()` change from `queueMicrotask` to `setTimeout(300ms)` in 19dffb0 introduced a race condition: two E2E tests waited for `localStorage.getItem("kml-heatmap-state") !== null`, which passed immediately from the initial save in `initialize()`, before the debounced save with updated state (heatmap toggled off) had fired. On page reload, the old state was restored.
Fix by waiting for the specific state value (`heatmapVisible === false`) instead of just checking for existence, matching the pattern already used by other tests (e.g., `buttonsHidden`).