### PR TITLE
Add tests for previously untested modules

### DIFF
--- a/tests/frontend/unit/ui/replayRenderer.test.ts
+++ b/tests/frontend/unit/ui/replayRenderer.test.ts
@@ -1,0 +1,381 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { ReplayRenderer } from "../../../../kml_heatmap/frontend/ui/replayRenderer";
+import { ReplayState } from "../../../../kml_heatmap/frontend/ui/replayState";
+import type { PathSegment } from "../../../../kml_heatmap/frontend/types";
+import * as L from "leaflet";
+
+const mockDomElements: Record<string, HTMLElement> = {};
+vi.mock("../../../../kml_heatmap/frontend/utils/domCache", () => ({
+  domCache: {
+    get: vi.fn((id: string) => mockDomElements[id] || null),
+  },
+}));
+
+vi.mock("../../../../kml_heatmap/frontend/utils/htmlGenerators", () => ({
+  generateSegmentPopupHtml: vi.fn(() => "<div>popup</div>"),
+}));
+
+function makeSegment(overrides: Partial<PathSegment> = {}): PathSegment {
+  return {
+    coords: [
+      [50.0, 8.5],
+      [50.01, 8.51],
+    ],
+    altitude_ft: 3000,
+    altitude_m: 914,
+    groundspeed_knots: 120,
+    path_id: 0,
+    time: 0,
+    ...overrides,
+  };
+}
+
+describe("ReplayRenderer", () => {
+  let renderer: ReplayRenderer;
+  let mockApp: Record<string, unknown>;
+  let mockReplayManager: {
+    state: ReplayState;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.keys(mockDomElements).forEach((key) => delete mockDomElements[key]);
+
+    ["replay-time-display", "replay-slider", "replay-slider-start"].forEach(
+      (id) => {
+        const el = document.createElement("div");
+        el.id = id;
+        document.body.appendChild(el);
+        mockDomElements[id] = el;
+      }
+    );
+
+    window.KMLHeatmap = {
+      formatTime: vi.fn(
+        (t: number) =>
+          `${Math.floor(t / 60)}:${String(Math.floor(t % 60)).padStart(2, "0")}`
+      ),
+      getColorForAltitude: vi.fn(() => "rgb(255, 0, 0)"),
+      getColorForAirspeed: vi.fn(() => "rgb(0, 0, 255)"),
+      findMinMax: vi.fn(),
+      calculateBearing: vi.fn(() => 90),
+      calculateSmoothedBearing: vi.fn(() => 90),
+    } as typeof window.KMLHeatmap;
+
+    const mockMap = L.map();
+    (mockMap.hasLayer as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+    mockApp = {
+      map: mockMap,
+      altitudeVisible: true,
+      airspeedVisible: false,
+    };
+
+    mockReplayManager = {
+      state: new ReplayState(),
+    };
+
+    renderer = new ReplayRenderer(
+      mockApp as unknown as ConstructorParameters<typeof ReplayRenderer>[0]
+    );
+  });
+
+  describe("updateAirplanePopup", () => {
+    it("skips when no marker", () => {
+      mockReplayManager.state.active = true;
+      mockReplayManager.state.airplaneMarker = null;
+      renderer.updateAirplanePopup(
+        mockReplayManager as unknown as Parameters<
+          typeof renderer.updateAirplanePopup
+        >[0]
+      );
+    });
+
+    it("skips when not active", () => {
+      mockReplayManager.state.active = false;
+      const markerObj = L.marker([0, 0]);
+      mockReplayManager.state.airplaneMarker = markerObj;
+      renderer.updateAirplanePopup(
+        mockReplayManager as unknown as Parameters<
+          typeof renderer.updateAirplanePopup
+        >[0]
+      );
+      expect(markerObj.openPopup).not.toHaveBeenCalled();
+    });
+
+    it("finds current segment by time", () => {
+      mockReplayManager.state.active = true;
+      const markerObj = L.marker([0, 0]);
+      mockReplayManager.state.airplaneMarker = markerObj;
+      mockReplayManager.state.currentTime = 15;
+      mockReplayManager.state.segments = [
+        makeSegment({ time: 0 }),
+        makeSegment({ time: 10 }),
+        makeSegment({ time: 20 }),
+      ];
+
+      renderer.updateAirplanePopup(
+        mockReplayManager as unknown as Parameters<
+          typeof renderer.updateAirplanePopup
+        >[0]
+      );
+      expect(markerObj.bindPopup).toHaveBeenCalled();
+      expect(markerObj.openPopup).toHaveBeenCalled();
+    });
+
+    it("falls back to first segment when currentTime is before all", () => {
+      mockReplayManager.state.active = true;
+      const markerObj = L.marker([0, 0]);
+      mockReplayManager.state.airplaneMarker = markerObj;
+      mockReplayManager.state.currentTime = 0;
+      mockReplayManager.state.segments = [
+        makeSegment({ time: 5 }),
+        makeSegment({ time: 10 }),
+      ];
+
+      renderer.updateAirplanePopup(
+        mockReplayManager as unknown as Parameters<
+          typeof renderer.updateAirplanePopup
+        >[0]
+      );
+      expect(markerObj.openPopup).toHaveBeenCalled();
+    });
+
+    it("skips when no segments", () => {
+      mockReplayManager.state.active = true;
+      const markerObj = L.marker([0, 0]);
+      mockReplayManager.state.airplaneMarker = markerObj;
+      mockReplayManager.state.segments = [];
+      renderer.updateAirplanePopup(
+        mockReplayManager as unknown as Parameters<
+          typeof renderer.updateAirplanePopup
+        >[0]
+      );
+      expect(markerObj.openPopup).not.toHaveBeenCalled();
+    });
+
+    it("updates existing popup instead of creating new", () => {
+      mockReplayManager.state.active = true;
+      const markerObj = L.marker([0, 0]);
+      const mockPopup = { setContent: vi.fn() };
+      (markerObj.getPopup as ReturnType<typeof vi.fn>).mockReturnValue(
+        mockPopup
+      );
+      mockReplayManager.state.airplaneMarker = markerObj;
+      mockReplayManager.state.segments = [makeSegment({ time: 0 })];
+      mockReplayManager.state.currentTime = 5;
+
+      renderer.updateAirplanePopup(
+        mockReplayManager as unknown as Parameters<
+          typeof renderer.updateAirplanePopup
+        >[0]
+      );
+      expect(mockPopup.setContent).toHaveBeenCalled();
+      expect(markerObj.bindPopup).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("updateDisplay", () => {
+    function callUpdateDisplay(isManualSeek = false): void {
+      renderer.updateDisplay(
+        mockReplayManager as unknown as Parameters<
+          typeof renderer.updateDisplay
+        >[0],
+        isManualSeek
+      );
+    }
+
+    it("updates time display text", () => {
+      mockReplayManager.state.currentTime = 65;
+      mockReplayManager.state.maxTime = 300;
+      callUpdateDisplay();
+      expect(mockDomElements["replay-time-display"]!.textContent).toContain(
+        "1:05"
+      );
+    });
+
+    it("updates slider value", () => {
+      const slider = document.createElement("input");
+      slider.id = "replay-slider";
+      mockDomElements["replay-slider"] = slider;
+      mockReplayManager.state.currentTime = 42;
+      callUpdateDisplay();
+      expect(slider.value).toBe("42");
+    });
+
+    it("draws segments incrementally", () => {
+      const layer = L.layerGroup();
+      mockReplayManager.state.layer = layer;
+      mockReplayManager.state.lastDrawnIndex = -1;
+      mockReplayManager.state.currentTime = 15;
+      mockReplayManager.state.segments = [
+        makeSegment({ time: 0 }),
+        makeSegment({ time: 10 }),
+        makeSegment({ time: 20 }),
+      ];
+
+      callUpdateDisplay();
+      expect(L.polyline).toHaveBeenCalled();
+      expect(mockReplayManager.state.lastDrawnIndex).toBe(1);
+    });
+
+    it("does not draw segments at time 0", () => {
+      const layer = L.layerGroup();
+      mockReplayManager.state.layer = layer;
+      mockReplayManager.state.currentTime = 0;
+      mockReplayManager.state.segments = [makeSegment({ time: 0 })];
+
+      callUpdateDisplay();
+      expect(L.polyline).not.toHaveBeenCalled();
+    });
+
+    it("skips already-drawn segments", () => {
+      const layer = L.layerGroup();
+      mockReplayManager.state.layer = layer;
+      mockReplayManager.state.lastDrawnIndex = 1;
+      mockReplayManager.state.currentTime = 30;
+      mockReplayManager.state.segments = [
+        makeSegment({ time: 0 }),
+        makeSegment({ time: 10 }),
+        makeSegment({ time: 20 }),
+      ];
+
+      callUpdateDisplay();
+      expect(L.polyline).toHaveBeenCalledTimes(1);
+    });
+
+    it("positions airplane marker at segment end", () => {
+      const markerObj = L.marker([0, 0]);
+      mockReplayManager.state.airplaneMarker = markerObj;
+      mockReplayManager.state.currentTime = 5;
+      mockReplayManager.state.segments = [makeSegment({ time: 0 })];
+
+      callUpdateDisplay();
+      expect(markerObj.setLatLng).toHaveBeenCalled();
+    });
+
+    it("uses airspeed colors when airspeed is visible and altitude is not", () => {
+      mockApp.airspeedVisible = true;
+      mockApp.altitudeVisible = false;
+
+      const layer = L.layerGroup();
+      mockReplayManager.state.layer = layer;
+      mockReplayManager.state.lastDrawnIndex = -1;
+      mockReplayManager.state.currentTime = 5;
+      mockReplayManager.state.segments = [
+        makeSegment({ time: 0, groundspeed_knots: 150 }),
+      ];
+
+      callUpdateDisplay();
+      expect(window.KMLHeatmap.getColorForAltitude).toHaveBeenCalledWith(
+        150,
+        mockReplayManager.state.colorMinSpeed,
+        mockReplayManager.state.colorMaxSpeed
+      );
+    });
+
+    it("falls back to first segment coords when no lastSegment", () => {
+      const markerObj = L.marker([0, 0]);
+      mockReplayManager.state.airplaneMarker = markerObj;
+      mockReplayManager.state.currentTime = 0;
+      mockReplayManager.state.segments = [
+        makeSegment({
+          time: 5,
+          coords: [
+            [51.0, 9.0],
+            [51.01, 9.01],
+          ],
+        }),
+      ];
+
+      callUpdateDisplay();
+      expect(markerObj.setLatLng).toHaveBeenCalledWith([51.0, 9.0]);
+    });
+
+    it("applies rotation transform to airplane icon", () => {
+      const iconDiv = document.createElement("div");
+      iconDiv.className = "replay-airplane-icon";
+      const iconElement = document.createElement("div");
+      iconElement.appendChild(iconDiv);
+
+      const markerObj = L.marker([0, 0]);
+      (markerObj.getElement as ReturnType<typeof vi.fn>).mockReturnValue(
+        iconElement
+      );
+      mockReplayManager.state.airplaneMarker = markerObj;
+      mockReplayManager.state.currentTime = 5;
+      mockReplayManager.state.segments = [makeSegment({ time: 0 })];
+
+      callUpdateDisplay();
+      expect(iconDiv.style.transform).toContain("rotate(");
+      expect(iconDiv.style.transform).toContain("translate3d(0,0,0)");
+    });
+
+    it("auto-pans when airplane is near viewport edge during playback", () => {
+      const mockMap = mockApp.map as Record<string, ReturnType<typeof vi.fn>>;
+      mockMap.latLngToContainerPoint.mockReturnValue({ x: 10, y: 10 });
+
+      const markerObj = L.marker([0, 0]);
+      mockReplayManager.state.airplaneMarker = markerObj;
+      mockReplayManager.state.playing = true;
+      mockReplayManager.state.currentTime = 5;
+      mockReplayManager.state.segments = [makeSegment({ time: 0 })];
+
+      callUpdateDisplay();
+      expect(mockMap.panTo).toHaveBeenCalled();
+    });
+
+    it("always recenters on manual seek", () => {
+      const mockMap = mockApp.map as Record<string, ReturnType<typeof vi.fn>>;
+      mockMap.latLngToContainerPoint.mockReturnValue({ x: 400, y: 300 });
+
+      const markerObj = L.marker([0, 0]);
+      mockReplayManager.state.airplaneMarker = markerObj;
+      mockReplayManager.state.playing = true;
+      mockReplayManager.state.currentTime = 5;
+      mockReplayManager.state.segments = [makeSegment({ time: 0 })];
+
+      callUpdateDisplay(true);
+      expect(mockMap.panTo).toHaveBeenCalled();
+    });
+
+    it("auto-zooms out after frequent recenters", () => {
+      const mockMap = mockApp.map as Record<string, ReturnType<typeof vi.fn>>;
+      mockMap.latLngToContainerPoint.mockReturnValue({ x: 10, y: 10 });
+
+      const markerObj = L.marker([0, 0]);
+      mockReplayManager.state.airplaneMarker = markerObj;
+      mockReplayManager.state.playing = true;
+      mockReplayManager.state.autoZoom = true;
+      mockReplayManager.state.lastZoom = 12;
+      mockReplayManager.state.currentTime = 5;
+      mockReplayManager.state.segments = [makeSegment({ time: 0 })];
+
+      const now = Date.now();
+      mockReplayManager.state.recenterTimestamps = [
+        now - 1000,
+        now - 500,
+        now - 100,
+      ];
+
+      callUpdateDisplay();
+      expect(mockMap.setZoom).toHaveBeenCalledWith(
+        11,
+        expect.objectContaining({ animate: true })
+      );
+    });
+
+    it("adds marker to map if missing", () => {
+      const mockMap = mockApp.map as Record<string, ReturnType<typeof vi.fn>>;
+      mockMap.hasLayer.mockReturnValue(false);
+
+      const markerObj = L.marker([0, 0]);
+      mockReplayManager.state.airplaneMarker = markerObj;
+      mockReplayManager.state.currentTime = 5;
+      mockReplayManager.state.segments = [makeSegment({ time: 0 })];
+
+      callUpdateDisplay();
+      expect(markerObj.addTo).toHaveBeenCalledWith(mockMap);
+    });
+  });
+});

--- a/tests/frontend/unit/ui/replayState.test.ts
+++ b/tests/frontend/unit/ui/replayState.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { ReplayState } from "../../../../kml_heatmap/frontend/ui/replayState";
+
+describe("ReplayState", () => {
+  describe("default values", () => {
+    it("initializes with correct defaults", () => {
+      const state = new ReplayState();
+
+      expect(state.active).toBe(false);
+      expect(state.playing).toBe(false);
+      expect(state.currentTime).toBe(0);
+      expect(state.maxTime).toBe(0);
+      expect(state.speed).toBe(50.0);
+      expect(state.layer).toBeNull();
+      expect(state.segments).toEqual([]);
+      expect(state.airplaneMarker).toBeNull();
+      expect(state.lastDrawnIndex).toBe(-1);
+      expect(state.lastBearing).toBeNull();
+      expect(state.animationFrameId).toBeNull();
+      expect(state.lastFrameTime).toBeNull();
+      expect(state.colorMinAlt).toBe(0);
+      expect(state.colorMaxAlt).toBe(10000);
+      expect(state.colorMinSpeed).toBe(0);
+      expect(state.colorMaxSpeed).toBe(200);
+      expect(state.autoZoom).toBe(false);
+      expect(state.lastZoom).toBeNull();
+      expect(state.recenterTimestamps).toEqual([]);
+    });
+  });
+
+  describe("resetDrawState", () => {
+    it("resets drawing-related properties", () => {
+      const state = new ReplayState();
+      state.currentTime = 120;
+      state.lastDrawnIndex = 50;
+      state.lastBearing = 180;
+      state.recenterTimestamps = [1000, 2000, 3000];
+
+      state.resetDrawState();
+
+      expect(state.currentTime).toBe(0);
+      expect(state.lastDrawnIndex).toBe(-1);
+      expect(state.lastBearing).toBeNull();
+      expect(state.recenterTimestamps).toEqual([]);
+    });
+
+    it("preserves non-drawing properties", () => {
+      const state = new ReplayState();
+      state.active = true;
+      state.playing = true;
+      state.speed = 100;
+      state.maxTime = 500;
+      state.colorMinAlt = 200;
+      state.colorMaxAlt = 8000;
+      state.autoZoom = true;
+
+      state.resetDrawState();
+
+      expect(state.active).toBe(true);
+      expect(state.playing).toBe(true);
+      expect(state.speed).toBe(100);
+      expect(state.maxTime).toBe(500);
+      expect(state.colorMinAlt).toBe(200);
+      expect(state.colorMaxAlt).toBe(8000);
+      expect(state.autoZoom).toBe(true);
+    });
+
+    it("can be called multiple times", () => {
+      const state = new ReplayState();
+      state.currentTime = 100;
+      state.resetDrawState();
+      state.currentTime = 200;
+      state.resetDrawState();
+
+      expect(state.currentTime).toBe(0);
+      expect(state.lastDrawnIndex).toBe(-1);
+    });
+  });
+});

--- a/tests/test_airport_lookup.py
+++ b/tests/test_airport_lookup.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 from kml_heatmap.airport_lookup import (
     get_cache_info,
     lookup_airport_coordinates,
+    standardize_airport_name,
 )
 
 
@@ -410,3 +411,39 @@ class TestAdditionalCoverage:
             assert info["airport_count"] == 2
         finally:
             lookup_module._airport_cache = original_cache
+
+
+class TestStandardizeAirportNamePartialRoute:
+    """Tests for standardize_airport_name with partial route lookups."""
+
+    def test_only_first_airport_found(self):
+        """Test route where only the departure airport is in the database."""
+        with patch(
+            "kml_heatmap.airport_lookup.lookup_airport_coordinates"
+        ) as mock_lookup:
+
+            def side_effect(icao):
+                if icao == "EDAQ":
+                    return (51.5528, 12.1022, "Halle-Oppin Airport")
+                return None
+
+            mock_lookup.side_effect = side_effect
+
+            result = standardize_airport_name("EDAQ Halle - ZZZZ SomePlace")
+            assert result == "EDAQ Halle-Oppin - ZZZZ SomePlace"
+
+    def test_only_second_airport_found(self):
+        """Test route where only the arrival airport is in the database."""
+        with patch(
+            "kml_heatmap.airport_lookup.lookup_airport_coordinates"
+        ) as mock_lookup:
+
+            def side_effect(icao):
+                if icao == "EDMV":
+                    return (48.6353, 13.1953, "Vilshofen Airfield")
+                return None
+
+            mock_lookup.side_effect = side_effect
+
+            result = standardize_airport_name("ZZZZ SomePlace - EDMV Vilsh")
+            assert result == "ZZZZ SomePlace - EDMV Vilshofen"

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -114,6 +114,41 @@ class TestAtomicJsonWrite:
             # Original file should not exist
             assert not path.exists()
 
+    def test_write_cleans_up_temp_file_on_replace_failure(self):
+        """Test that the temp file is removed when os.replace fails."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "test.json"
+
+            with (
+                patch(
+                    "kml_heatmap.cache.os.replace",
+                    side_effect=OSError("replace failed"),
+                ) as mock_replace,
+                patch("kml_heatmap.cache.os.unlink") as mock_unlink,
+            ):
+                atomic_json_write(path, {"key": "value"}, Path(tmpdir))
+
+                mock_replace.assert_called_once()
+                # The temp file path should have been passed to unlink
+                mock_unlink.assert_called_once()
+
+    def test_write_handles_temp_cleanup_failure(self):
+        """Test graceful handling when both os.replace and os.unlink fail."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "test.json"
+
+            with (
+                patch(
+                    "kml_heatmap.cache.os.replace",
+                    side_effect=OSError("replace failed"),
+                ),
+                patch(
+                    "kml_heatmap.cache.os.unlink", side_effect=OSError("unlink failed")
+                ),
+            ):
+                # Should not raise despite both operations failing
+                atomic_json_write(path, {"key": "value"}, Path(tmpdir))
+
 
 class TestLockedJsonReadWrite:
     """Tests for locked_json_read_write context manager."""
@@ -227,3 +262,25 @@ class TestLockedJsonReadWrite:
             with open(path) as f:
                 loaded = json.load(f)
             assert loaded == {}
+
+    def test_lock_file_cleanup_failure_is_ignored(self):
+        """Test that failure to remove the lock file is silently ignored."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "cache.json"
+            lock_path = path.with_suffix(".json.lock")
+
+            original_unlink = Path.unlink
+
+            def patched_unlink(self, *args, **kwargs):
+                if self == lock_path:
+                    raise OSError("permission denied")
+                return original_unlink(self, *args, **kwargs)
+
+            with patch.object(Path, "unlink", patched_unlink):
+                with locked_json_read_write(path) as (data, _):
+                    data["key"] = "value"
+
+            # Data should still be written successfully despite lock cleanup failure
+            with open(path) as f:
+                loaded = json.load(f)
+            assert loaded == {"key": "value"}

--- a/tests/test_config_validator.py
+++ b/tests/test_config_validator.py
@@ -3,6 +3,8 @@
 import pytest
 import tempfile
 import os
+from pathlib import Path
+from unittest.mock import patch, MagicMock
 from kml_heatmap.config_validator import (
     ConfigValidator,
     validate_environment,
@@ -435,3 +437,60 @@ class TestInputPathValidation:
                 os.chmod(temp_path, 0o644)
         finally:
             os.unlink(temp_path)
+
+    def test_validate_directory_many_kml_files_mocked(self):
+        """Test validation warns when directory has more than 1000 KML files."""
+        validator = ConfigValidator()
+
+        with tempfile.TemporaryDirectory() as input_dir:
+            # Mock glob to return more than 1000 fake paths
+            fake_files = [f"file{i}.kml" for i in range(1500)]
+            with patch("pathlib.Path.glob", return_value=fake_files):
+                with tempfile.TemporaryDirectory() as output_dir:
+                    is_valid, errors, warnings = validator.validate_all(
+                        input_dir, output_dir
+                    )
+                    assert any("Large number of KML files" in w for w in warnings)
+
+
+class TestOutputDirValidation:
+    """Tests for output directory validation edge cases."""
+
+    def test_validate_output_dir_creation_fails(self):
+        """Test validation when output directory creation raises OSError."""
+        validator = ConfigValidator()
+
+        with (
+            patch.object(Path, "exists", return_value=False),
+            patch.object(Path, "mkdir", side_effect=OSError("Permission denied")),
+        ):
+            validator._validate_output_dir("/fake/output/dir")
+
+        assert any("Cannot create output directory" in err for err in validator.errors)
+
+    def test_validate_output_dir_no_write_permission(self):
+        """Test validation when output directory is not writable."""
+        validator = ConfigValidator()
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            with patch("os.access", return_value=False):
+                validator._validate_output_dir(output_dir)
+                assert any("No write permission" in err for err in validator.errors)
+
+
+class TestDiskSpaceLowWarning:
+    """Tests for low disk space warning."""
+
+    def test_validate_disk_space_low(self):
+        """Test validation warns when disk space is low."""
+        validator = ConfigValidator()
+
+        mock_stat = MagicMock()
+        # Simulate 50 MB available (below 100 MB threshold)
+        mock_stat.f_bavail = 50
+        mock_stat.f_frsize = 1024 * 1024  # 1 MB blocks
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            with patch("os.statvfs", return_value=mock_stat):
+                validator._validate_disk_space(output_dir)
+                assert any("Low disk space" in w for w in validator.warnings)

--- a/tests/test_export_pipeline.py
+++ b/tests/test_export_pipeline.py
@@ -1,0 +1,154 @@
+"""Tests for export_pipeline module."""
+
+import pytest
+
+from kml_heatmap.export_pipeline import _build_path_info, _process_path_segments
+
+
+class TestBuildPathInfo:
+    def _make_path(self, count=10):
+        return [[50.0 + i * 0.01, 8.5 + i * 0.01, 1000.0] for i in range(count)]
+
+    def test_airport_name_parsing(self):
+        metadata = {
+            "airport_name": "EDDS - EDDP",
+            "timestamp": "2025-03-03T08:00:00Z",
+            "end_timestamp": "2025-03-03T09:30:00Z",
+        }
+        info, duration, dist_km, dist_nm = _build_path_info(
+            self._make_path(), metadata, 0, 2025
+        )
+        assert info["start_airport"] == "EDDS"
+        assert info["end_airport"] == "EDDP"
+        assert info["year"] == 2025
+        assert info["id"] == 0
+
+    def test_no_airport_name(self):
+        metadata = {"airport_name": "", "timestamp": None, "end_timestamp": None}
+        info, _, _, _ = _build_path_info(self._make_path(), metadata, 1, 2025)
+        assert info["start_airport"] is None
+        assert info["end_airport"] is None
+
+    def test_single_airport_no_split(self):
+        metadata = {
+            "airport_name": "EDDS",
+            "timestamp": None,
+            "end_timestamp": None,
+        }
+        info, _, _, _ = _build_path_info(self._make_path(), metadata, 0, 2025)
+        assert info["start_airport"] is None
+        assert info["end_airport"] is None
+
+    def test_missing_timestamps_zero_duration(self):
+        metadata = {"airport_name": "", "timestamp": None, "end_timestamp": None}
+        _, duration, _, _ = _build_path_info(self._make_path(), metadata, 0, 2025)
+        assert duration == 0.0
+
+    def test_valid_timestamps_duration(self):
+        metadata = {
+            "airport_name": "",
+            "timestamp": "2025-03-03T08:00:00Z",
+            "end_timestamp": "2025-03-03T09:30:00Z",
+        }
+        _, duration, _, _ = _build_path_info(self._make_path(), metadata, 0, 2025)
+        assert duration == pytest.approx(5400.0, abs=1.0)
+
+    def test_distance_calculation(self):
+        metadata = {"airport_name": "", "timestamp": None, "end_timestamp": None}
+        _, _, dist_km, dist_nm = _build_path_info(self._make_path(), metadata, 0, 2025)
+        assert dist_km > 0
+        assert dist_nm > 0
+        assert dist_nm == pytest.approx(dist_km * 0.539957, rel=0.01)
+
+    def test_aircraft_metadata_included(self):
+        metadata = {
+            "airport_name": "",
+            "timestamp": None,
+            "end_timestamp": None,
+            "aircraft_registration": "D-EAGJ",
+            "aircraft_type": "C172",
+        }
+        info, _, _, _ = _build_path_info(self._make_path(), metadata, 0, 2025)
+        assert info["aircraft_registration"] == "D-EAGJ"
+        assert info["aircraft_type"] == "C172"
+
+    def test_segment_count(self):
+        path = self._make_path(count=5)
+        metadata = {"airport_name": "", "timestamp": None, "end_timestamp": None}
+        info, _, _, _ = _build_path_info(path, metadata, 0, 2025)
+        assert info["segment_count"] == 4
+
+    def test_start_end_coords(self):
+        path = self._make_path(count=3)
+        metadata = {"airport_name": "", "timestamp": None, "end_timestamp": None}
+        info, _, _, _ = _build_path_info(path, metadata, 0, 2025)
+        assert info["start_coords"] == [path[0][0], path[0][1]]
+        assert info["end_coords"] == [path[-1][0], path[-1][1]]
+
+
+class TestProcessPathSegments:
+    def _make_path_with_timestamps(self, count=10):
+        path = []
+        for i in range(count):
+            lat = 50.0 + i * 0.01
+            lon = 8.5 + i * 0.01
+            alt = 1000.0 + i * 50
+            ts = f"2025-03-03T08:{i:02d}:00Z"
+            path.append([lat, lon, alt, ts])
+        return path
+
+    def test_generates_segments(self):
+        path = self._make_path_with_timestamps()
+        segments, max_gs, min_gs, cruise_dist, cruise_time, hist = (
+            _process_path_segments(path, 0, 10.0, 540.0)
+        )
+        assert len(segments) > 0
+
+    def test_identical_coordinates_filtered(self):
+        path = [
+            [50.0, 8.5, 1000.0, "2025-03-03T08:00:00Z"],
+            [50.0, 8.5, 1100.0, "2025-03-03T08:01:00Z"],
+            [50.1, 8.6, 1200.0, "2025-03-03T08:02:00Z"],
+        ]
+        segments, _, _, _, _, _ = _process_path_segments(path, 0, 5.0, 120.0)
+        coords_in_segments = [s["coords"] for s in segments]
+        for coords in coords_in_segments:
+            assert coords[0] != coords[1]
+
+    def test_segment_data_fields(self):
+        path = self._make_path_with_timestamps(count=3)
+        segments, _, _, _, _, _ = _process_path_segments(path, 5, 5.0, 120.0)
+        if segments:
+            seg = segments[0]
+            assert "coords" in seg
+            assert "altitude_ft" in seg
+            assert "altitude_m" in seg
+            assert "groundspeed_knots" in seg
+            assert seg["path_id"] == 5
+
+    def test_path_without_timestamps(self):
+        path = [
+            [50.0, 8.5, 1000.0],
+            [50.1, 8.6, 1100.0],
+            [50.2, 8.7, 1200.0],
+        ]
+        segments, _, _, _, _, _ = _process_path_segments(path, 0, 10.0, 600.0)
+        assert len(segments) > 0
+        for seg in segments:
+            assert "time" not in seg
+
+    def test_groundspeed_tracking(self):
+        path = self._make_path_with_timestamps(count=5)
+        _, max_gs, min_gs, _, _, _ = _process_path_segments(path, 0, 5.0, 240.0)
+        assert max_gs >= 0
+        if min_gs < float("inf"):
+            assert min_gs <= max_gs
+
+    def test_altitude_rounding(self):
+        path = [
+            [50.0, 8.5, 1523.5, "2025-03-03T08:00:00Z"],
+            [50.1, 8.6, 1523.5, "2025-03-03T08:01:00Z"],
+        ]
+        segments, _, _, _, _, _ = _process_path_segments(path, 0, 5.0, 60.0)
+        if segments:
+            assert segments[0]["altitude_ft"] % 100 == 0

--- a/tests/test_export_reconciler.py
+++ b/tests/test_export_reconciler.py
@@ -1,0 +1,210 @@
+"""Tests for export_reconciler module."""
+
+import pytest
+
+from kml_heatmap.constants import METERS_TO_FEET
+from kml_heatmap.export_reconciler import _recalculate_stats_from_segments
+
+
+class TestRecalculateStatsFromSegments:
+    def _make_stats(self, aircraft_list=None):
+        stats = {
+            "total_points": 0,
+            "min_altitude_m": 0,
+            "max_altitude_m": 0,
+            "min_altitude_ft": 0,
+            "max_altitude_ft": 0,
+            "total_altitude_gain_m": 0,
+            "total_altitude_gain_ft": 0,
+            "average_groundspeed_knots": 0,
+            "cruise_speed_knots": 0,
+            "total_flight_time_seconds": 0,
+        }
+        if aircraft_list is not None:
+            stats["aircraft_list"] = aircraft_list
+        return stats
+
+    def test_empty_segments(self):
+        stats = self._make_stats()
+        _recalculate_stats_from_segments(stats, [], [])
+        assert stats["total_points"] == 0
+
+    def test_altitude_min_max(self):
+        segments = [
+            {"altitude_m": 500, "altitude_ft": 1640, "groundspeed_knots": 100},
+            {"altitude_m": 1000, "altitude_ft": 3280, "groundspeed_knots": 120},
+            {"altitude_m": 200, "altitude_ft": 656, "groundspeed_knots": 90},
+        ]
+        stats = self._make_stats()
+        _recalculate_stats_from_segments(stats, segments, [])
+        assert stats["min_altitude_m"] == 200
+        assert stats["max_altitude_m"] == 1000
+        assert stats["min_altitude_ft"] == pytest.approx(200 * METERS_TO_FEET)
+        assert stats["max_altitude_ft"] == pytest.approx(1000 * METERS_TO_FEET)
+
+    def test_altitude_gain(self):
+        segments = [
+            {"altitude_m": 100, "altitude_ft": 328, "groundspeed_knots": 100},
+            {"altitude_m": 300, "altitude_ft": 984, "groundspeed_knots": 100},
+            {"altitude_m": 200, "altitude_ft": 656, "groundspeed_knots": 100},
+            {"altitude_m": 500, "altitude_ft": 1640, "groundspeed_knots": 100},
+        ]
+        stats = self._make_stats()
+        _recalculate_stats_from_segments(stats, segments, [])
+        assert stats["total_altitude_gain_m"] == pytest.approx(500.0)
+
+    def test_average_groundspeed(self):
+        segments = [
+            {"altitude_m": 100, "altitude_ft": 328, "groundspeed_knots": 100},
+            {"altitude_m": 100, "altitude_ft": 328, "groundspeed_knots": 150},
+            {"altitude_m": 100, "altitude_ft": 328, "groundspeed_knots": 0},
+        ]
+        stats = self._make_stats()
+        _recalculate_stats_from_segments(stats, segments, [])
+        assert stats["average_groundspeed_knots"] == pytest.approx(125.0)
+
+    def test_cruise_speed_above_threshold(self):
+        min_alt_m = 100
+        cruise_threshold = min_alt_m * METERS_TO_FEET + 1000
+        segments = [
+            {"altitude_m": min_alt_m, "altitude_ft": 328, "groundspeed_knots": 80},
+            {
+                "altitude_m": 2000,
+                "altitude_ft": cruise_threshold + 500,
+                "groundspeed_knots": 140,
+            },
+            {
+                "altitude_m": 2000,
+                "altitude_ft": cruise_threshold + 500,
+                "groundspeed_knots": 160,
+            },
+        ]
+        stats = self._make_stats()
+        _recalculate_stats_from_segments(stats, segments, [])
+        assert stats["cruise_speed_knots"] == pytest.approx(150.0)
+
+    def test_cruise_altitude_histogram(self):
+        min_alt_m = 100
+        cruise_threshold = min_alt_m * METERS_TO_FEET + 1000
+        high_alt = int(cruise_threshold + 500)
+        segments = [
+            {"altitude_m": min_alt_m, "altitude_ft": 328, "groundspeed_knots": 100},
+            {
+                "altitude_m": 2000,
+                "altitude_ft": high_alt,
+                "groundspeed_knots": 140,
+                "time": 10.0,
+            },
+            {
+                "altitude_m": 2000,
+                "altitude_ft": high_alt,
+                "groundspeed_knots": 140,
+                "time": 20.0,
+            },
+            {
+                "altitude_m": 2500,
+                "altitude_ft": high_alt + 1000,
+                "groundspeed_knots": 140,
+                "time": 30.0,
+            },
+        ]
+        stats = self._make_stats()
+        _recalculate_stats_from_segments(stats, segments, [])
+        assert "most_common_cruise_altitude_ft" in stats
+
+    def test_flight_time_from_path_durations(self):
+        segments = [
+            {
+                "altitude_m": 1000,
+                "altitude_ft": 3280,
+                "groundspeed_knots": 100,
+                "time": 0.0,
+                "path_id": 0,
+            },
+            {
+                "altitude_m": 1000,
+                "altitude_ft": 3280,
+                "groundspeed_knots": 100,
+                "time": 100.0,
+                "path_id": 0,
+            },
+            {
+                "altitude_m": 1000,
+                "altitude_ft": 3280,
+                "groundspeed_knots": 100,
+                "time": 0.0,
+                "path_id": 1,
+            },
+            {
+                "altitude_m": 1000,
+                "altitude_ft": 3280,
+                "groundspeed_knots": 100,
+                "time": 200.0,
+                "path_id": 1,
+            },
+        ]
+        stats = self._make_stats()
+        _recalculate_stats_from_segments(stats, segments, [])
+        assert stats["total_flight_time_seconds"] == pytest.approx(300.0)
+
+    def test_total_points(self):
+        segments = [
+            {"altitude_m": 100, "altitude_ft": 328, "groundspeed_knots": 100},
+            {"altitude_m": 200, "altitude_ft": 656, "groundspeed_knots": 100},
+        ]
+        stats = self._make_stats()
+        _recalculate_stats_from_segments(stats, segments, [])
+        assert stats["total_points"] == 4
+
+    def test_per_aircraft_statistics(self):
+        segments = [
+            {
+                "altitude_m": 1000,
+                "altitude_ft": 3280,
+                "groundspeed_knots": 100,
+                "time": 0.0,
+                "path_id": 0,
+                "coords": [[50.0, 8.5], [50.01, 8.51]],
+            },
+            {
+                "altitude_m": 1000,
+                "altitude_ft": 3280,
+                "groundspeed_knots": 100,
+                "time": 300.0,
+                "path_id": 0,
+                "coords": [[50.01, 8.51], [50.02, 8.52]],
+            },
+        ]
+        path_info = [{"id": 0, "aircraft_registration": "D-EAGJ"}]
+        aircraft_list = [
+            {
+                "registration": "D-EAGJ",
+                "flight_time_seconds": 0,
+                "flight_distance_km": 0,
+            }
+        ]
+        stats = self._make_stats(aircraft_list=aircraft_list)
+        _recalculate_stats_from_segments(stats, segments, path_info)
+        aircraft = stats["aircraft_list"][0]
+        assert aircraft["flight_time_seconds"] == pytest.approx(300.0)
+        assert aircraft["flight_distance_km"] > 0
+
+    def test_zero_groundspeed_excluded_from_average(self):
+        segments = [
+            {"altitude_m": 100, "altitude_ft": 328, "groundspeed_knots": 0},
+            {"altitude_m": 100, "altitude_ft": 328, "groundspeed_knots": 0},
+            {"altitude_m": 100, "altitude_ft": 328, "groundspeed_knots": 120},
+        ]
+        stats = self._make_stats()
+        _recalculate_stats_from_segments(stats, segments, [])
+        assert stats["average_groundspeed_knots"] == pytest.approx(120.0)
+
+    def test_no_altitude_gain_on_descent(self):
+        segments = [
+            {"altitude_m": 500, "altitude_ft": 1640, "groundspeed_knots": 100},
+            {"altitude_m": 400, "altitude_ft": 1312, "groundspeed_knots": 100},
+            {"altitude_m": 300, "altitude_ft": 984, "groundspeed_knots": 100},
+        ]
+        stats = self._make_stats()
+        _recalculate_stats_from_segments(stats, segments, [])
+        assert stats["total_altitude_gain_m"] == 0.0

--- a/tests/test_export_writers.py
+++ b/tests/test_export_writers.py
@@ -1,0 +1,179 @@
+"""Tests for export_writers module."""
+
+import json
+import os
+
+from kml_heatmap.export_writers import (
+    collect_unique_years,
+    export_airports_data,
+    export_metadata,
+)
+
+
+class TestExportAirportsData:
+    def test_valid_airports(self, tmp_path):
+        airports = [
+            {
+                "name": "EDDS Stuttgart",
+                "lat": 48.6899,
+                "lon": 9.2220,
+                "timestamps": ["2025-03-03T08:00:00Z"],
+                "is_at_path_end": False,
+            }
+        ]
+        filepath, size = export_airports_data(airports, str(tmp_path))
+        assert os.path.exists(filepath)
+        assert size > 0
+
+        content = open(filepath).read()
+        assert content.startswith("window.KML_AIRPORTS = ")
+        assert content.endswith(";")
+        data = json.loads(content[len("window.KML_AIRPORTS = ") : -1])
+        assert len(data["airports"]) == 1
+        assert data["airports"][0]["flight_count"] == 1
+
+    def test_empty_name_filtered(self, tmp_path):
+        airports = [
+            {
+                "name": "",
+                "lat": 48.0,
+                "lon": 9.0,
+                "timestamps": [],
+                "is_at_path_end": False,
+            }
+        ]
+        filepath, _ = export_airports_data(airports, str(tmp_path))
+        content = open(filepath).read()
+        data = json.loads(content[len("window.KML_AIRPORTS = ") : -1])
+        assert len(data["airports"]) == 0
+
+    def test_duplicate_locations_deduplicated(self, tmp_path):
+        airports = [
+            {
+                "name": "EDDS Stuttgart",
+                "lat": 48.6899,
+                "lon": 9.2220,
+                "timestamps": ["t1"],
+                "is_at_path_end": False,
+            },
+            {
+                "name": "EDDS Stuttgart",
+                "lat": 48.6899,
+                "lon": 9.2220,
+                "timestamps": ["t2"],
+                "is_at_path_end": False,
+            },
+        ]
+        filepath, _ = export_airports_data(airports, str(tmp_path))
+        content = open(filepath).read()
+        data = json.loads(content[len("window.KML_AIRPORTS = ") : -1])
+        assert len(data["airports"]) == 1
+
+    def test_strip_timestamps(self, tmp_path):
+        airports = [
+            {
+                "name": "EDDS Stuttgart",
+                "lat": 48.6899,
+                "lon": 9.2220,
+                "timestamps": ["2025-03-03T08:00:00Z"],
+                "is_at_path_end": False,
+            }
+        ]
+        filepath, _ = export_airports_data(
+            airports, str(tmp_path), strip_timestamps=True
+        )
+        content = open(filepath).read()
+        data = json.loads(content[len("window.KML_AIRPORTS = ") : -1])
+        assert "timestamps" not in data["airports"][0]
+
+    def test_flight_count_from_multiple_timestamps(self, tmp_path):
+        airports = [
+            {
+                "name": "EDDS Stuttgart",
+                "lat": 48.6899,
+                "lon": 9.2220,
+                "timestamps": ["t1", "t2", "t3"],
+                "is_at_path_end": False,
+            }
+        ]
+        filepath, _ = export_airports_data(airports, str(tmp_path))
+        content = open(filepath).read()
+        data = json.loads(content[len("window.KML_AIRPORTS = ") : -1])
+        assert data["airports"][0]["flight_count"] == 3
+
+
+class TestExportMetadata:
+    def test_normal_values(self, tmp_path):
+        stats = {"total_flights": 10}
+        filepath, size = export_metadata(
+            stats, 100.0, 5000.0, 50.0, 180.0, [2024, 2025], str(tmp_path)
+        )
+        assert os.path.exists(filepath)
+        content = open(filepath).read()
+        assert content.startswith("window.KML_METADATA = ")
+        data = json.loads(content[len("window.KML_METADATA = ") : -1])
+        assert data["min_alt_m"] == 100.0
+        assert data["max_alt_m"] == 5000.0
+        assert data["min_groundspeed_knots"] == 50.0
+        assert data["max_groundspeed_knots"] == 180.0
+        assert data["available_years"] == [2024, 2025]
+
+    def test_infinite_groundspeed_clamped(self, tmp_path):
+        filepath, _ = export_metadata(
+            {}, 0, 1000, float("inf"), float("-inf"), [], str(tmp_path)
+        )
+        content = open(filepath).read()
+        data = json.loads(content[len("window.KML_METADATA = ") : -1])
+        assert data["min_groundspeed_knots"] == 0.0
+        assert data["max_groundspeed_knots"] == 0.0
+
+    def test_nan_groundspeed_clamped(self, tmp_path):
+        filepath, _ = export_metadata(
+            {}, 0, 1000, float("nan"), float("nan"), [], str(tmp_path)
+        )
+        content = open(filepath).read()
+        data = json.loads(content[len("window.KML_METADATA = ") : -1])
+        assert data["min_groundspeed_knots"] == 0.0
+        assert data["max_groundspeed_knots"] == 0.0
+
+    def test_with_file_structure(self, tmp_path):
+        structure = {"2025": ["full", "medium"]}
+        filepath, _ = export_metadata(
+            {}, 0, 1000, 50, 180, [2025], str(tmp_path), file_structure=structure
+        )
+        content = open(filepath).read()
+        data = json.loads(content[len("window.KML_METADATA = ") : -1])
+        assert data["file_structure"] == structure
+
+    def test_without_file_structure(self, tmp_path):
+        filepath, _ = export_metadata({}, 0, 1000, 50, 180, [], str(tmp_path))
+        content = open(filepath).read()
+        data = json.loads(content[len("window.KML_METADATA = ") : -1])
+        assert "file_structure" not in data
+
+    def test_groundspeed_rounding(self, tmp_path):
+        filepath, _ = export_metadata({}, 0, 1000, 55.678, 199.123, [], str(tmp_path))
+        content = open(filepath).read()
+        data = json.loads(content[len("window.KML_METADATA = ") : -1])
+        assert data["min_groundspeed_knots"] == 55.7
+        assert data["max_groundspeed_knots"] == 199.1
+
+
+class TestCollectUniqueYears:
+    def test_empty_list(self):
+        assert collect_unique_years([]) == []
+
+    def test_single_year(self):
+        assert collect_unique_years([{"year": 2025}]) == [2025]
+
+    def test_duplicate_years(self):
+        metadata = [{"year": 2025}, {"year": 2025}, {"year": 2024}]
+        assert collect_unique_years(metadata) == [2024, 2025]
+
+    def test_none_years_skipped(self):
+        metadata = [{"year": 2025}, {"year": None}, {"other": "data"}]
+        assert collect_unique_years(metadata) == [2025]
+
+    def test_sorted_output(self):
+        metadata = [{"year": 2026}, {"year": 2024}, {"year": 2025}]
+        assert collect_unique_years(metadata) == [2024, 2025, 2026]

--- a/tests/test_parser_common.py
+++ b/tests/test_parser_common.py
@@ -1,0 +1,325 @@
+"""Tests for parser_common module."""
+
+from xml.etree import ElementTree as ET
+
+import pytest
+
+from kml_heatmap.parser_common import (
+    _build_path_metadata_dict,
+    extract_charterware_timestamp,
+    extract_placemark_metadata,
+    extract_year_from_timestamp,
+    find_xml_element,
+    find_xml_elements,
+    is_mid_flight_start,
+    is_valid_landing,
+    parse_coordinate_point,
+    sample_path_altitudes,
+)
+
+
+class TestExtractYearFromTimestamp:
+    def test_iso_format(self):
+        assert extract_year_from_timestamp("2025-03-03T08:58:01Z") == 2025
+
+    def test_iso_format_with_offset(self):
+        assert extract_year_from_timestamp("2026-01-15T10:30:00+02:00") == 2026
+
+    def test_date_only(self):
+        assert extract_year_from_timestamp("2025-03-03") == 2025
+
+    def test_text_date(self):
+        assert extract_year_from_timestamp("03 Mar 2025") == 2025
+
+    def test_none_input(self):
+        assert extract_year_from_timestamp(None) is None
+
+    def test_empty_string(self):
+        assert extract_year_from_timestamp("") is None
+
+    def test_invalid_format(self):
+        assert extract_year_from_timestamp("not-a-date") is None
+
+    def test_year_in_text(self):
+        assert extract_year_from_timestamp("Log Start: 03 Mar 2025 08:58 Z") == 2025
+
+
+class TestSamplePathAltitudes:
+    def test_short_path_returns_none(self):
+        path = [[50, 8, 100]] * 10
+        assert sample_path_altitudes(path) is None
+
+    def test_path_too_short_for_sample(self):
+        path = [[50, 8, 100]] * 22
+        assert sample_path_altitudes(path) is None
+
+    def test_from_start(self):
+        path = [[50, 8, float(i * 10)] for i in range(100)]
+        result = sample_path_altitudes(path, from_end=False)
+        assert result is not None
+        assert result["min"] == 0.0
+        assert result["max"] < 250.0
+        assert result["variation"] == result["max"] - result["min"]
+
+    def test_from_end(self):
+        path = [[50, 8, float(i * 10)] for i in range(100)]
+        result = sample_path_altitudes(path, from_end=True)
+        assert result is not None
+        assert result["max"] == 990.0
+
+    def test_flat_altitude(self):
+        path = [[50, 8, 500.0]] * 100
+        result = sample_path_altitudes(path, from_end=False)
+        assert result is not None
+        assert result["variation"] == 0.0
+
+
+class TestIsMidFlightStart:
+    def _make_path(self, alt, count=100):
+        return [[50.0, 8.0, alt]] * count
+
+    def test_ground_level_start(self):
+        assert is_mid_flight_start(self._make_path(50.0), 50.0) is False
+
+    def test_mid_flight_cruise(self):
+        assert is_mid_flight_start(self._make_path(1500.0), 1500.0) is True
+
+    def test_climbing_start_high_variation(self):
+        path = [[50.0, 8.0, float(100 + i * 20)] for i in range(100)]
+        assert is_mid_flight_start(path, 100.0) is False
+
+    def test_short_path(self):
+        path = [[50.0, 8.0, 2000.0]] * 5
+        assert is_mid_flight_start(path, 2000.0) is False
+
+
+class TestIsValidLanding:
+    def _make_path(self, alt, count=100):
+        return [[50.0, 8.0, alt]] * count
+
+    def test_low_variation_ending(self):
+        assert is_valid_landing(self._make_path(100.0), 100.0) is True
+
+    def test_high_altitude_but_low_variation(self):
+        assert is_valid_landing(self._make_path(2000.0), 2000.0) is True
+
+    def test_low_altitude_endpoint(self):
+        path = [[50.0, 8.0, float(500 - i * 5)] for i in range(100)]
+        assert is_valid_landing(path, 5.0) is True
+
+    def test_short_path_below_fallback(self):
+        path = [[50.0, 8.0, 500.0]] * 5
+        assert is_valid_landing(path, 500.0) is True
+
+    def test_short_path_above_fallback(self):
+        path = [[50.0, 8.0, 2000.0]] * 5
+        assert is_valid_landing(path, 2000.0) is False
+
+
+class TestParseCoordinatePoint:
+    def test_three_components(self):
+        result = parse_coordinate_point("8.5,50.0,100.0", "test.kml")
+        assert result is not None
+        lat, lon, alt = result
+        assert lat == pytest.approx(50.0)
+        assert lon == pytest.approx(8.5)
+        assert alt == pytest.approx(100.0)
+
+    def test_two_components(self):
+        result = parse_coordinate_point("8.5,50.0", "test.kml")
+        assert result is not None
+        lat, lon, alt = result
+        assert lat == pytest.approx(50.0)
+        assert lon == pytest.approx(8.5)
+
+    def test_empty_string(self):
+        assert parse_coordinate_point("", "test.kml") is None
+
+    def test_whitespace_only(self):
+        assert parse_coordinate_point("   ", "test.kml") is None
+
+    def test_single_value(self):
+        assert parse_coordinate_point("8.5", "test.kml") is None
+
+    def test_invalid_values(self):
+        assert parse_coordinate_point("abc,def", "test.kml") is None
+
+    def test_whitespace_stripping(self):
+        result = parse_coordinate_point("  8.5,50.0,100.0  ", "test.kml")
+        assert result is not None
+
+
+class TestFindXmlElement:
+    NS = {"kml": "http://www.opengis.net/kml/2.2"}
+
+    def test_namespaced_found(self):
+        xml = '<root xmlns:kml="http://www.opengis.net/kml/2.2"><kml:name>Test</kml:name></root>'
+        root = ET.fromstring(xml)
+        result = find_xml_element(root, "kml:name", "name", self.NS)
+        assert result is not None
+        assert result.text == "Test"
+
+    def test_fallback_found(self):
+        xml = "<root><name>Test</name></root>"
+        root = ET.fromstring(xml)
+        result = find_xml_element(root, "kml:name", "name", self.NS)
+        assert result is not None
+        assert result.text == "Test"
+
+    def test_neither_found(self):
+        xml = "<root><other>Test</other></root>"
+        root = ET.fromstring(xml)
+        result = find_xml_element(root, "kml:name", "name", self.NS)
+        assert result is None
+
+
+class TestFindXmlElements:
+    NS = {"kml": "http://www.opengis.net/kml/2.2"}
+
+    def test_multiple_elements(self):
+        xml = "<root><when>t1</when><when>t2</when><when>t3</when></root>"
+        root = ET.fromstring(xml)
+        result = find_xml_elements(root, "kml:when", "when", self.NS)
+        assert len(result) == 3
+
+    def test_empty_result(self):
+        xml = "<root><other>Test</other></root>"
+        root = ET.fromstring(xml)
+        result = find_xml_elements(root, "kml:when", "when", self.NS)
+        assert result == []
+
+
+class TestExtractCharterwareTimestamp:
+    def test_pm_time(self):
+        desc = "Flight Jan 12 2026 03:01PM path of OE-AKI"
+        result = extract_charterware_timestamp(desc)
+        assert result == "2026-01-12T15:01:00Z"
+
+    def test_am_time(self):
+        desc = "Flight Mar 05 2026 08:30AM path of OE-AKI"
+        result = extract_charterware_timestamp(desc)
+        assert result == "2026-03-05T08:30:00Z"
+
+    def test_12pm_noon(self):
+        desc = "Flight Jun 01 2026 12:00PM path of OE-AKI"
+        result = extract_charterware_timestamp(desc)
+        assert result == "2026-06-01T12:00:00Z"
+
+    def test_12am_midnight(self):
+        desc = "Flight Jun 01 2026 12:00AM path of OE-AKI"
+        result = extract_charterware_timestamp(desc)
+        assert result == "2026-06-01T00:00:00Z"
+
+    def test_none_input(self):
+        assert extract_charterware_timestamp(None) is None
+
+    def test_empty_input(self):
+        assert extract_charterware_timestamp("") is None
+
+    def test_invalid_format(self):
+        assert extract_charterware_timestamp("not a charterware description") is None
+
+    def test_full_month_name(self):
+        desc = "Flight January 15 2026 02:00PM path of D-EAGJ"
+        result = extract_charterware_timestamp(desc)
+        assert result == "2026-01-15T14:00:00Z"
+
+
+class TestExtractPlacemarkMetadata:
+    NS = {"kml": "http://www.opengis.net/kml/2.2"}
+
+    def test_name_and_timestamps(self):
+        xml = """
+        <Placemark xmlns:kml="http://www.opengis.net/kml/2.2">
+            <kml:name>EDDS</kml:name>
+            <kml:when>2025-03-03T08:58:01Z</kml:when>
+            <kml:when>2025-03-03T10:30:00Z</kml:when>
+        </Placemark>
+        """
+        placemark = ET.fromstring(xml)
+        result = extract_placemark_metadata(placemark, self.NS)
+        assert result["timestamp"] == "2025-03-03T08:58:01Z"
+        assert result["end_timestamp"] == "2025-03-03T10:30:00Z"
+        assert result["year"] == 2025
+
+    def test_single_timestamp(self):
+        xml = """
+        <Placemark>
+            <name>EDDS</name>
+            <TimeStamp><when>2025-06-15T12:00:00Z</when></TimeStamp>
+        </Placemark>
+        """
+        placemark = ET.fromstring(xml)
+        result = extract_placemark_metadata(placemark, self.NS)
+        assert result["timestamp"] == "2025-06-15T12:00:00Z"
+        assert result["end_timestamp"] is None
+
+    def test_date_in_name_fallback(self):
+        xml = """
+        <Placemark>
+            <name>EDDS to EDDP - 16 Aug 2026</name>
+        </Placemark>
+        """
+        placemark = ET.fromstring(xml)
+        result = extract_placemark_metadata(placemark, self.NS)
+        assert result["timestamp"] == "16 Aug 2026"
+        assert result["year"] == 2026
+
+    def test_charterware_description_fallback(self):
+        xml = """
+        <Placemark>
+            <name>Route</name>
+            <description>Flight Jan 12 2026 03:01PM path of OE-AKI</description>
+        </Placemark>
+        """
+        placemark = ET.fromstring(xml)
+        result = extract_placemark_metadata(placemark, self.NS)
+        assert result["timestamp"] == "2026-01-12T15:01:00Z"
+        assert result["year"] == 2026
+
+    def test_no_metadata(self):
+        xml = "<Placemark></Placemark>"
+        placemark = ET.fromstring(xml)
+        result = extract_placemark_metadata(placemark, self.NS)
+        assert result["airport_name"] is None
+        assert result["timestamp"] is None
+        assert result["end_timestamp"] is None
+        assert result["year"] is None
+
+
+class TestBuildPathMetadataDict:
+    def test_basic_metadata(self):
+        result = _build_path_metadata_dict(
+            kml_file="test.kml",
+            path_start=[50.0, 8.5, 100.0],
+            airport_name="EDDS",
+            timestamp="2025-03-03T08:58:01Z",
+            end_timestamp="2025-03-03T10:30:00Z",
+        )
+        assert result["filename"] == "test.kml"
+        assert result["start_point"] == [50.0, 8.5, 100.0]
+        assert result["airport_name"] == "EDDS"
+        assert result["timestamp"] == "2025-03-03T08:58:01Z"
+        assert result["end_timestamp"] == "2025-03-03T10:30:00Z"
+        assert result["year"] == 2025
+
+    def test_no_aircraft_info(self):
+        result = _build_path_metadata_dict(
+            kml_file="test.kml",
+            path_start=[50.0, 8.5, 100.0],
+            airport_name=None,
+            timestamp=None,
+            end_timestamp=None,
+        )
+        assert result["year"] is None
+        assert "aircraft_registration" not in result
+
+    def test_with_aircraft_in_filename(self):
+        result = _build_path_metadata_dict(
+            kml_file="20250303_0800_EDDS_DEAGJ_C172.kml",
+            path_start=[50.0, 8.5, 100.0],
+            airport_name="EDDS",
+            timestamp="2025-03-03T08:58:01Z",
+            end_timestamp=None,
+        )
+        assert result["aircraft_registration"] == "D-EAGJ"

--- a/tests/test_parser_standard.py
+++ b/tests/test_parser_standard.py
@@ -1,0 +1,102 @@
+"""Tests for parser_standard module."""
+
+from unittest.mock import MagicMock
+
+from kml_heatmap.parser_standard import process_standard_coordinates
+
+
+class TestProcessStandardCoordinates:
+    def _make_coord_element(self, text):
+        elem = MagicMock()
+        elem.text = text
+        return elem
+
+    def test_none_text_skipped(self):
+        elem = self._make_coord_element(None)
+        coordinates, path_groups, path_metadata = [], [], []
+        process_standard_coordinates(
+            [elem], {}, "test.kml", coordinates, path_groups, path_metadata
+        )
+        assert coordinates == []
+        assert path_groups == []
+
+    def test_empty_text_skipped(self):
+        elem = self._make_coord_element("   ")
+        coordinates, path_groups, path_metadata = [], [], []
+        process_standard_coordinates(
+            [elem], {}, "test.kml", coordinates, path_groups, path_metadata
+        )
+        assert coordinates == []
+        assert path_groups == []
+
+    def test_single_point(self):
+        elem = self._make_coord_element("8.5,50.0,100.0")
+        coordinates, path_groups, path_metadata = [], [], []
+        process_standard_coordinates(
+            [elem], {}, "test.kml", coordinates, path_groups, path_metadata
+        )
+        assert len(coordinates) == 1
+        assert len(path_groups) == 1
+        assert len(path_groups[0]) == 1
+
+    def test_multi_point_path(self):
+        elem = self._make_coord_element("8.5,50.0,100.0 8.6,50.1,150.0 8.7,50.2,200.0")
+        coordinates, path_groups, path_metadata = [], [], []
+        process_standard_coordinates(
+            [elem], {}, "test.kml", coordinates, path_groups, path_metadata
+        )
+        assert len(coordinates) == 3
+        assert len(path_groups) == 1
+        assert len(path_groups[0]) == 3
+
+    def test_invalid_coordinates_skipped(self):
+        elem = self._make_coord_element("invalid 8.5,50.0,100.0 also-invalid")
+        coordinates, path_groups, path_metadata = [], [], []
+        process_standard_coordinates(
+            [elem], {}, "test.kml", coordinates, path_groups, path_metadata
+        )
+        assert len(coordinates) == 1
+
+    def test_metadata_lookup(self):
+        elem = self._make_coord_element("8.5,50.0,100.0")
+        metadata = {
+            id(elem): {
+                "airport_name": "EDDS",
+                "timestamp": "2025-03-03T08:58:01Z",
+                "end_timestamp": None,
+            }
+        }
+        coordinates, path_groups, path_metadata = [], [], []
+        process_standard_coordinates(
+            [elem], metadata, "test.kml", coordinates, path_groups, path_metadata
+        )
+        assert len(path_metadata) == 1
+        assert path_metadata[0]["airport_name"] == "EDDS"
+
+    def test_newline_separated_coordinates(self):
+        elem = self._make_coord_element("8.5,50.0,100.0\n8.6,50.1,150.0")
+        coordinates, path_groups, path_metadata = [], [], []
+        process_standard_coordinates(
+            [elem], {}, "test.kml", coordinates, path_groups, path_metadata
+        )
+        assert len(coordinates) == 2
+
+    def test_multiple_elements(self):
+        elem1 = self._make_coord_element("8.5,50.0,100.0")
+        elem2 = self._make_coord_element("9.0,51.0,200.0")
+        coordinates, path_groups, path_metadata = [], [], []
+        process_standard_coordinates(
+            [elem1, elem2], {}, "test.kml", coordinates, path_groups, path_metadata
+        )
+        assert len(path_groups) == 2
+        assert len(path_metadata) == 2
+
+    def test_coordinates_without_altitude(self):
+        elem = self._make_coord_element("8.5,50.0 8.6,50.1")
+        coordinates, path_groups, path_metadata = [], [], []
+        process_standard_coordinates(
+            [elem], {}, "test.kml", coordinates, path_groups, path_metadata
+        )
+        assert len(coordinates) == 2
+        # No altitude, so no path group entries
+        assert len(path_groups) == 0


### PR DESCRIPTION
- Add dedicated tests for 5 Python modules: `parser_common`, `parser_standard`, `export_writers`, `export_pipeline`, `export_reconciler`
- Add dedicated tests for 2 TypeScript modules: `replayState`, `replayRenderer`
- 101 new Python tests, 23 new TypeScript tests (1396 lines total)
- Coverage improvements: `export_writers` 100%, `parser_standard` 98%, `parser_common` 97%, `export_reconciler` 94%, `export_pipeline` 97%