### PR TITLE
Refactor large functions, fix error handling, add Bandit CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,6 +151,20 @@ jobs:
       - name: Run E2E tests
         run: npm run test:e2e
 
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.x"
+          cache: "pip"
+      - name: Install Bandit
+        run: pip install bandit
+      - name: Run Bandit security scan
+        run: bandit -r kml_heatmap -ll
+
   typos:
     runs-on: ubuntu-latest
     steps:

--- a/kml_heatmap/aircraft.py
+++ b/kml_heatmap/aircraft.py
@@ -141,7 +141,7 @@ def _fetch_aircraft_model(registration: str) -> Optional[str]:
         )
         _last_request_time = time.monotonic()
 
-        with urllib.request.urlopen(req, timeout=10) as response:
+        with urllib.request.urlopen(req, timeout=10) as response:  # nosec B310
             html = response.read().decode("utf-8")
 
         parser = AircraftDataParser()

--- a/kml_heatmap/airport_lookup.py
+++ b/kml_heatmap/airport_lookup.py
@@ -79,7 +79,7 @@ def _download_airport_database() -> bool:
         CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
         logger.info("📥 Downloading OurAirports database...")
-        urlretrieve(OURAIRPORTS_URL, CACHE_FILE)
+        urlretrieve(OURAIRPORTS_URL, CACHE_FILE)  # nosec B310
 
         # Verify downloaded file
         if CACHE_FILE.exists() and CACHE_FILE.stat().st_size > 0:
@@ -173,12 +173,12 @@ def _load_airport_database() -> Dict[str, Tuple[float, float, str]]:
                 try:
                     fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
                     lock_file.close()
-                except Exception:
+                except OSError:
                     pass
             elif lock_file:
                 try:
                     lock_file.close()
-                except Exception:
+                except OSError:
                     pass
 
 

--- a/kml_heatmap/data_exporter.py
+++ b/kml_heatmap/data_exporter.py
@@ -25,8 +25,9 @@ import os
 import json
 import shutil
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Tuple
 
+from .geometry import extract_altitudes
 from .logger import logger
 from .constants import DATA_RESOLUTION
 from .export_writers import export_airports_data, export_metadata, collect_unique_years
@@ -203,60 +204,20 @@ def process_year_data(
     }
 
 
-def export_all_data(
-    all_coordinates: List[List[float]],
+def _calculate_altitude_range(
     all_path_groups: List[List[List[float]]],
-    all_path_metadata: List[Dict[str, Any]],
-    unique_airports: List[Dict[str, Any]],
-    stats: Dict[str, Any],
-    output_dir: str = "data",
-    strip_timestamps: bool = False,
-) -> Dict[str, str]:
-    """
-    Orchestrate the full data export pipeline.
-
-    Cleans the output directory, groups paths by year, processes each year
-    in parallel, exports airports and metadata, and aggregates statistics.
-
-    Args:
-        all_coordinates: List of [lat, lon] pairs
-        all_path_groups: List of path groups with altitude data
-        all_path_metadata: List of metadata dicts for each path
-        unique_airports: List of airport dicts
-        stats: Statistics dictionary (modified in place with aggregated data)
-        output_dir: Directory to save data files
-        strip_timestamps: If True, remove timestamps for privacy
-
-    Returns:
-        Dict mapping file types to output paths (e.g., {"airports": "...", "metadata": "..."}).
-    """
-    # Clean up existing output directory
-    if os.path.exists(output_dir):
-        logger.info(f"\n  Cleaning up output directory: {output_dir}")
-        shutil.rmtree(output_dir)
-
-    os.makedirs(output_dir, exist_ok=True)
-
-    logger.info("\n  Exporting data to JS files...")
-    if strip_timestamps:
-        logger.info("  Privacy mode: Stripping all date/time information")
-
-    # Calculate min/max altitude for color mapping
+) -> Tuple[float, float]:
+    """Calculate min/max altitude across all path groups."""
     if all_path_groups:
-        all_altitudes = [coord[2] for path in all_path_groups for coord in path]
-        min_alt_m = min(all_altitudes)
-        max_alt_m = max(all_altitudes)
-    else:
-        min_alt_m = 0
-        max_alt_m = 1000
+        all_altitudes = extract_altitudes(all_path_groups)
+        return min(all_altitudes), max(all_altitudes)
+    return 0.0, 1000.0
 
-    # Single full resolution
-    resolutions = {
-        DATA_RESOLUTION: {"factor": 1, "epsilon": 0, "description": "Full resolution"}
-    }
-    resolution_order = [DATA_RESOLUTION]
 
-    # Group paths by year
+def _group_paths_by_year(
+    all_path_metadata: List[Dict[str, Any]],
+) -> Dict[str, List[int]]:
+    """Group path indices by year from metadata."""
     paths_by_year: Dict[str, List[int]] = {}
     for path_idx, metadata in enumerate(all_path_metadata):
         year = metadata.get("year")
@@ -267,25 +228,23 @@ def export_all_data(
         if year not in paths_by_year:
             paths_by_year[year] = []
         paths_by_year[year].append(path_idx)
+    return paths_by_year
 
-    logger.info(f"\n  Splitting data by year: {sorted(paths_by_year.keys())}")
 
-    # Aggregate tracking
-    files: Dict[str, str] = {}
-    file_structure: Dict[str, Any] = {}
-    max_groundspeed_knots = 0.0
-    min_groundspeed_knots = float("inf")
-    cruise_speed_total_distance = 0.0
-    cruise_speed_total_time = 0.0
-    max_path_distance_nm = 0.0
-    cruise_altitude_histogram: Dict[int, float] = {}
-    all_full_res_segments: List[Dict[str, Any]] = []
-    all_full_res_path_info: List[Dict[str, Any]] = []
+def _process_years_parallel(
+    paths_by_year: Dict[str, List[int]],
+    all_coordinates: List[List[float]],
+    all_path_groups: List[List[List[float]]],
+    all_path_metadata: List[Dict[str, Any]],
+    min_alt_m: float,
+    max_alt_m: float,
+    output_dir: str,
+    resolutions: Dict[str, Dict[str, Any]],
+    resolution_order: List[str],
+) -> List[Dict[str, Any]]:
+    """Process all years in parallel and return results."""
+    year_results: List[Dict[str, Any]] = []
 
-    # Process years in parallel
-    logger.info(f"\n  Processing {len(paths_by_year)} year(s) in parallel...")
-
-    year_results = []
     with ThreadPoolExecutor(
         max_workers=min(len(paths_by_year), os.cpu_count() or 4)
     ) as executor:
@@ -304,7 +263,7 @@ def export_all_data(
                 output_dir,
                 resolutions,
                 resolution_order,
-                True,  # quiet=True for parallel execution
+                True,
             )
             futures[future] = year
 
@@ -323,10 +282,42 @@ def export_all_data(
                 logger.info(
                     f"  [{completed_count}/{total_years}] Year {year}: {year_points:,} points"
                 )
-            except Exception as e:
-                logger.error(f"  Error processing year {year}: {e}")
+            except Exception:
+                logger.exception(f"  Error processing year {year}")
 
-    # Aggregate results from all years
+    return year_results
+
+
+def _aggregate_year_results(
+    year_results: List[Dict[str, Any]],
+) -> Tuple[
+    Dict[str, Any],
+    float,
+    float,
+    float,
+    float,
+    float,
+    Dict[int, float],
+    List[Dict[str, Any]],
+    List[Dict[str, Any]],
+]:
+    """Aggregate statistics from all year results.
+
+    Returns:
+        Tuple of (file_structure, max_groundspeed, min_groundspeed,
+                  cruise_distance, cruise_time, max_path_distance,
+                  cruise_altitude_histogram, all_segments, all_path_info)
+    """
+    file_structure: Dict[str, Any] = {}
+    max_groundspeed_knots = 0.0
+    min_groundspeed_knots = float("inf")
+    cruise_speed_total_distance = 0.0
+    cruise_speed_total_time = 0.0
+    max_path_distance_nm = 0.0
+    cruise_altitude_histogram: Dict[int, float] = {}
+    all_full_res_segments: List[Dict[str, Any]] = []
+    all_full_res_path_info: List[Dict[str, Any]] = []
+
     for result in year_results:
         year = result["year"]
         file_structure[year] = result["file_structure"]
@@ -347,7 +338,6 @@ def export_all_data(
                 cruise_altitude_histogram[altitude_bin] = 0
             cruise_altitude_histogram[altitude_bin] += time_spent
 
-        # Collect full resolution data from all years with remapped path_ids
         year_segments = result["full_res_segments"]
         year_path_info = result["full_res_path_info"]
         if year_segments and year_path_info:
@@ -361,20 +351,30 @@ def export_all_data(
                 remapped["id"] = pi["id"] + path_id_offset
                 all_full_res_path_info.append(remapped)
 
-    # Export airports
-    airports_file, _ = export_airports_data(
-        unique_airports, output_dir, strip_timestamps
+    return (
+        file_structure,
+        max_groundspeed_knots,
+        min_groundspeed_knots,
+        cruise_speed_total_distance,
+        cruise_speed_total_time,
+        max_path_distance_nm,
+        cruise_altitude_histogram,
+        all_full_res_segments,
+        all_full_res_path_info,
     )
-    files["airports"] = airports_file
 
-    # Collect unique years
-    available_years = collect_unique_years(all_path_metadata)
 
-    # Update stats with aggregated data
+def _finalize_stats(
+    stats: Dict[str, Any],
+    max_groundspeed_knots: float,
+    min_groundspeed_knots: float,
+    cruise_speed_total_distance: float,
+    cruise_speed_total_time: float,
+    max_path_distance_nm: float,
+    cruise_altitude_histogram: Dict[int, float],
+) -> None:
+    """Update stats dict with aggregated cruise/groundspeed/altitude data."""
     stats["max_groundspeed_knots"] = round(max_groundspeed_knots, 1)
-
-    if min_groundspeed_knots == float("inf"):
-        min_groundspeed_knots = 0.0
 
     if cruise_speed_total_time > 0:
         cruise_speed_knots = (
@@ -399,14 +399,106 @@ def export_all_data(
     stats["longest_flight_nm"] = round(max_path_distance_nm, 1)
     stats["longest_flight_km"] = round(max_path_distance_nm * 1.852, 1)
 
-    # Recalculate stats from segment data for frontend consistency
+
+def export_all_data(
+    all_coordinates: List[List[float]],
+    all_path_groups: List[List[List[float]]],
+    all_path_metadata: List[Dict[str, Any]],
+    unique_airports: List[Dict[str, Any]],
+    stats: Dict[str, Any],
+    output_dir: str = "data",
+    strip_timestamps: bool = False,
+) -> Dict[str, str]:
+    """Orchestrate the full data export pipeline.
+
+    Cleans the output directory, groups paths by year, processes each year
+    in parallel, exports airports and metadata, and aggregates statistics.
+
+    Args:
+        all_coordinates: List of [lat, lon] pairs
+        all_path_groups: List of path groups with altitude data
+        all_path_metadata: List of metadata dicts for each path
+        unique_airports: List of airport dicts
+        stats: Statistics dictionary (modified in place with aggregated data)
+        output_dir: Directory to save data files
+        strip_timestamps: If True, remove timestamps for privacy
+
+    Returns:
+        Dict mapping file types to output paths.
+    """
+    if os.path.exists(output_dir):
+        logger.info(f"\n  Cleaning up output directory: {output_dir}")
+        shutil.rmtree(output_dir)
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    logger.info("\n  Exporting data to JS files...")
+    if strip_timestamps:
+        logger.info("  Privacy mode: Stripping all date/time information")
+
+    min_alt_m, max_alt_m = _calculate_altitude_range(all_path_groups)
+
+    resolutions = {
+        DATA_RESOLUTION: {"factor": 1, "epsilon": 0, "description": "Full resolution"}
+    }
+    resolution_order = [DATA_RESOLUTION]
+
+    paths_by_year = _group_paths_by_year(all_path_metadata)
+    logger.info(f"\n  Splitting data by year: {sorted(paths_by_year.keys())}")
+
+    logger.info(f"\n  Processing {len(paths_by_year)} year(s) in parallel...")
+    year_results = _process_years_parallel(
+        paths_by_year,
+        all_coordinates,
+        all_path_groups,
+        all_path_metadata,
+        min_alt_m,
+        max_alt_m,
+        output_dir,
+        resolutions,
+        resolution_order,
+    )
+
+    (
+        file_structure,
+        max_groundspeed_knots,
+        min_groundspeed_knots,
+        cruise_speed_total_distance,
+        cruise_speed_total_time,
+        max_path_distance_nm,
+        cruise_altitude_histogram,
+        all_full_res_segments,
+        all_full_res_path_info,
+    ) = _aggregate_year_results(year_results)
+
+    if min_groundspeed_knots == float("inf"):
+        min_groundspeed_knots = 0.0
+
+    _finalize_stats(
+        stats,
+        max_groundspeed_knots,
+        min_groundspeed_knots,
+        cruise_speed_total_distance,
+        cruise_speed_total_time,
+        max_path_distance_nm,
+        cruise_altitude_histogram,
+    )
+
     if all_full_res_segments and all_full_res_path_info:
         logger.info("\n  Reconciling statistics from segment data...")
         _recalculate_stats_from_segments(
             stats, all_full_res_segments, all_full_res_path_info
         )
 
-    # Export metadata (final, consistent values)
+    files: Dict[str, str] = {}
+
+    airports_file, _ = export_airports_data(
+        unique_airports, output_dir, strip_timestamps
+    )
+    files["airports"] = airports_file
+
+    available_years = collect_unique_years(all_path_metadata)
+
     meta_file, _ = export_metadata(
         stats,
         min_alt_m,

--- a/kml_heatmap/geometry.py
+++ b/kml_heatmap/geometry.py
@@ -10,6 +10,7 @@ __all__ = [
     "haversine_distance",
     "downsample_coordinates",
     "get_altitude_color",
+    "extract_altitudes",
 ]
 
 # Constants
@@ -18,6 +19,11 @@ EARTH_RADIUS_KM = 6371
 # Type aliases
 Coordinate2D = List[float]  # [lat, lon]
 Coordinate3D = List[float]  # [lat, lon, alt]
+
+
+def extract_altitudes(paths: List[List[List[float]]]) -> List[float]:
+    """Extract all altitude values from a list of paths."""
+    return [coord[2] for path in paths for coord in path]
 
 
 def haversine_distance(lat1: float, lon1: float, lat2: float, lon2: float) -> float:

--- a/kml_heatmap/renderer.py
+++ b/kml_heatmap/renderer.py
@@ -305,35 +305,16 @@ def _render_html(output_file: str, data_dir_name: str) -> None:
     )
 
 
-def _package_assets(
+def _generate_map_config(
     output_dir: str,
+    templates_dir: Path,
     bounds: Dict[str, float],
     data_dir_name: str,
 ) -> None:
-    """Build JS bundles (if needed), generate config, and copy static assets.
-
-    Args:
-        output_dir: Directory to write output files.
-        bounds: Dict with min_lat, max_lat, min_lon, max_lon, center_lat, center_lon.
-        data_dir_name: Base name of the data directory.
-    """
-    static_dir = Path(__file__).parent / "static"
-    templates_dir = Path(__file__).parent / "templates"
-
+    """Generate minified map_config.js from template."""
     stadia_api_key = os.environ.get("STADIA_API_KEY", "")
     openaip_api_key = os.environ.get("OPENAIP_API_KEY", "")
 
-    # Build JavaScript bundles if needed
-    if not (
-        (static_dir / "bundle.js").exists()
-        and (static_dir / "mapApp.bundle.js").exists()
-    ):
-        logger.info("\nBuilding JavaScript modules...")
-        _build_javascript_bundle()
-    else:
-        logger.info("\nUsing pre-built JavaScript bundles...")
-
-    # Generate map_config.js
     map_config_template_path = templates_dir / "map_config_template.js"
     map_config_dst = os.path.join(output_dir, "map_config.js")
 
@@ -362,7 +343,9 @@ def _package_assets(
         f"Configuration generated: {map_config_dst} ({map_config_size / 1024:.1f} KB)"
     )
 
-    # Copy JavaScript bundles
+
+def _copy_javascript_bundles(output_dir: str, static_dir: Path) -> None:
+    """Copy JavaScript bundle files to output directory."""
     for bundle_name in ("bundle.js", "mapApp.bundle.js"):
         src = static_dir / bundle_name
         dst = os.path.join(output_dir, bundle_name)
@@ -373,7 +356,9 @@ def _package_assets(
         else:
             logger.warning(f"{bundle_name} not found - run npm build to generate it")
 
-    # Copy and minify CSS
+
+def _copy_and_minify_css(output_dir: str, static_dir: Path) -> None:
+    """Copy and minify CSS to output directory."""
     styles_css_src = static_dir / "styles.css"
     styles_css_dst = os.path.join(output_dir, "styles.css")
 
@@ -388,7 +373,9 @@ def _package_assets(
     styles_css_size = os.path.getsize(styles_css_dst)
     logger.info(f"CSS copied: {styles_css_dst} ({styles_css_size / 1024:.1f} KB)")
 
-    # Copy favicon files
+
+def _copy_favicon_files(output_dir: str, static_dir: Path) -> None:
+    """Copy favicon and manifest files to output directory."""
     for favicon_file in (
         "favicon.svg",
         "favicon.ico",
@@ -403,6 +390,30 @@ def _package_assets(
             shutil.copy2(src, dst)
 
     logger.info(f"Favicon files copied to {output_dir}")
+
+
+def _package_assets(
+    output_dir: str,
+    bounds: Dict[str, float],
+    data_dir_name: str,
+) -> None:
+    """Build JS bundles (if needed), generate config, and copy static assets."""
+    static_dir = Path(__file__).parent / "static"
+    templates_dir = Path(__file__).parent / "templates"
+
+    if not (
+        (static_dir / "bundle.js").exists()
+        and (static_dir / "mapApp.bundle.js").exists()
+    ):
+        logger.info("\nBuilding JavaScript modules...")
+        _build_javascript_bundle()
+    else:
+        logger.info("\nUsing pre-built JavaScript bundles...")
+
+    _generate_map_config(output_dir, templates_dir, bounds, data_dir_name)
+    _copy_javascript_bundles(output_dir, static_dir)
+    _copy_and_minify_css(output_dir, static_dir)
+    _copy_favicon_files(output_dir, static_dir)
 
 
 def create_progressive_heatmap(

--- a/kml_heatmap/statistics.py
+++ b/kml_heatmap/statistics.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timezone
 from typing import List, Dict, Optional, Any, Tuple
-from .geometry import haversine_distance
+from .geometry import haversine_distance, extract_altitudes
 from .aircraft import lookup_aircraft_model
 from .airports import is_point_marker
 from .constants import METERS_TO_FEET, KM_TO_NAUTICAL_MILES, SECONDS_PER_HOUR
@@ -90,7 +90,7 @@ def calculate_altitude_stats(
         Dict with min/max altitude in meters and feet
     """
     # Collect all altitudes
-    all_altitudes = [coord[2] for path in valid_paths for coord in path]
+    all_altitudes = extract_altitudes(valid_paths)
 
     if not all_altitudes:
         return {

--- a/tests/test_airport_lookup.py
+++ b/tests/test_airport_lookup.py
@@ -8,6 +8,7 @@ import pytest
 from unittest.mock import patch
 
 from kml_heatmap.airport_lookup import (
+    _load_airport_database,
     get_cache_info,
     lookup_airport_coordinates,
     standardize_airport_name,
@@ -447,3 +448,27 @@ class TestStandardizeAirportNamePartialRoute:
 
             result = standardize_airport_name("ZZZZ SomePlace - EDMV Vilsh")
             assert result == "ZZZZ SomePlace - EDMV Vilshofen"
+
+
+class TestLoadAirportDatabaseLockCleanup:
+    def test_lock_release_failure_is_handled(self):
+        import kml_heatmap.airport_lookup as mod
+
+        original_cache = mod._airport_cache
+        mod._airport_cache = None
+        try:
+            original_flock = mod.fcntl.flock
+            call_count = 0
+
+            def flock_side_effect(fd, op):
+                nonlocal call_count
+                call_count += 1
+                if op == mod.fcntl.LOCK_UN:
+                    raise OSError("mock unlock failure")
+                return original_flock(fd, op)
+
+            with patch.object(mod.fcntl, "flock", side_effect=flock_side_effect):
+                result = _load_airport_database()
+            assert isinstance(result, dict)
+        finally:
+            mod._airport_cache = original_cache

--- a/tests/test_data_exporter.py
+++ b/tests/test_data_exporter.py
@@ -3,7 +3,14 @@
 import os
 import json
 import tempfile
+from unittest.mock import patch
+
 from kml_heatmap.data_exporter import (
+    _aggregate_year_results,
+    _calculate_altitude_range,
+    _finalize_stats,
+    _group_paths_by_year,
+    _process_years_parallel,
     _recalculate_stats_from_segments,
     export_airports_data,
     export_metadata,
@@ -877,3 +884,156 @@ class TestRecalculateStatsFromSegments:
 
         # Should not crash, no aircraft keys added
         assert "aircraft_list" not in stats
+
+
+class TestCalculateAltitudeRange:
+    def test_with_paths(self):
+        paths = [[[50.0, 8.5, 100.0], [50.1, 8.6, 500.0]]]
+        min_alt, max_alt = _calculate_altitude_range(paths)
+        assert min_alt == 100.0
+        assert max_alt == 500.0
+
+    def test_empty_paths(self):
+        min_alt, max_alt = _calculate_altitude_range([])
+        assert min_alt == 0.0
+        assert max_alt == 1000.0
+
+
+class TestGroupPathsByYear:
+    def test_groups_by_year(self):
+        metadata = [
+            {"year": 2025},
+            {"year": 2026},
+            {"year": 2025},
+        ]
+        result = _group_paths_by_year(metadata)
+        assert result == {"2025": [0, 2], "2026": [1]}
+
+    def test_none_year_becomes_unknown(self):
+        metadata = [{"year": None}, {"other": "data"}]
+        result = _group_paths_by_year(metadata)
+        assert result == {"unknown": [0, 1]}
+
+
+class TestAggregateYearResults:
+    def test_aggregates_groundspeed(self):
+        results = [
+            {
+                "year": "2025",
+                "max_groundspeed": 150.0,
+                "min_groundspeed": 50.0,
+                "cruise_distance": 100.0,
+                "cruise_time": 60.0,
+                "max_path_distance": 80.0,
+                "cruise_altitude_histogram": {3000: 10.0},
+                "file_structure": ["data"],
+                "full_res_segments": None,
+                "full_res_path_info": None,
+            }
+        ]
+        (
+            file_structure,
+            max_gs,
+            min_gs,
+            cruise_dist,
+            cruise_time,
+            max_path_dist,
+            cruise_hist,
+            segments,
+            path_info,
+        ) = _aggregate_year_results(results)
+        assert max_gs == 150.0
+        assert min_gs == 50.0
+        assert cruise_dist == 100.0
+        assert cruise_time == 60.0
+        assert max_path_dist == 80.0
+        assert cruise_hist == {3000: 10.0}
+        assert file_structure == {"2025": ["data"]}
+
+    def test_remaps_path_ids_across_years(self):
+        results = [
+            {
+                "year": "2025",
+                "max_groundspeed": 0,
+                "min_groundspeed": float("inf"),
+                "cruise_distance": 0,
+                "cruise_time": 0,
+                "max_path_distance": 0,
+                "cruise_altitude_histogram": {},
+                "file_structure": [],
+                "full_res_segments": [{"path_id": 0, "data": "seg1"}],
+                "full_res_path_info": [{"id": 0, "data": "info1"}],
+            },
+            {
+                "year": "2026",
+                "max_groundspeed": 0,
+                "min_groundspeed": float("inf"),
+                "cruise_distance": 0,
+                "cruise_time": 0,
+                "max_path_distance": 0,
+                "cruise_altitude_histogram": {},
+                "file_structure": [],
+                "full_res_segments": [{"path_id": 0, "data": "seg2"}],
+                "full_res_path_info": [{"id": 0, "data": "info2"}],
+            },
+        ]
+        *_, segments, path_info = _aggregate_year_results(results)
+        assert segments[0]["path_id"] == 0
+        assert segments[1]["path_id"] == 1
+        assert path_info[0]["id"] == 0
+        assert path_info[1]["id"] == 1
+
+
+class TestFinalizeStats:
+    def test_cruise_speed_calculation(self):
+        stats: dict = {}
+        _finalize_stats(stats, 180.0, 50.0, 1000.0, 100.0, 200.0, {})
+        assert stats["max_groundspeed_knots"] == 180.0
+        assert stats["cruise_speed_knots"] == 36000.0
+        assert stats["longest_flight_nm"] == 200.0
+
+    def test_no_cruise_time(self):
+        stats: dict = {}
+        _finalize_stats(stats, 100.0, 50.0, 0.0, 0.0, 100.0, {})
+        assert stats["cruise_speed_knots"] == 0
+
+    def test_cruise_altitude_histogram(self):
+        stats: dict = {}
+        _finalize_stats(stats, 100.0, 50.0, 0.0, 0.0, 0.0, {5000: 30.0, 3000: 10.0})
+        assert stats["most_common_cruise_altitude_ft"] == 5000
+
+    def test_empty_cruise_histogram(self):
+        stats: dict = {}
+        _finalize_stats(stats, 100.0, 50.0, 0.0, 0.0, 0.0, {})
+        assert stats["most_common_cruise_altitude_ft"] == 0
+        assert stats["most_common_cruise_altitude_m"] == 0
+
+
+class TestProcessYearsParallel:
+    def test_handles_processing_error(self):
+        paths_by_year = {"2025": [0]}
+        with patch(
+            "kml_heatmap.data_exporter.process_year_data",
+            side_effect=RuntimeError("boom"),
+        ):
+            results = _process_years_parallel(
+                paths_by_year, [], [[]], [{}], 0, 1000, "/tmp", {}, []
+            )
+        assert results == []
+
+
+class TestExportAllDataPrivacyMode:
+    def test_strip_timestamps_log(self, tmp_path):
+        output_dir = str(tmp_path / "out")
+        paths = [[[50.0, 8.5, 100.0], [50.1, 8.6, 200.0]]]
+        metadata = [{"year": 2025, "airport_name": "EDDS"}]
+        stats: dict = {}
+        export_all_data(
+            [[50.0, 8.5]],
+            paths,
+            metadata,
+            [],
+            stats,
+            output_dir,
+            strip_timestamps=True,
+        )


### PR DESCRIPTION
- Split `export_all_data()` (220 lines) into 5 focused helpers: `_calculate_altitude_range()`, `_group_paths_by_year()`, `_process_years_parallel()`, `_aggregate_year_results()`, `_finalize_stats()`
- Split `_package_assets()` (98 lines) into 4 single-responsibility helpers: `_generate_map_config()`, `_copy_javascript_bundles()`, `_copy_and_minify_css()`, `_copy_favicon_files()`
- Extract shared `extract_altitudes()` utility to `geometry.py`, replacing duplicate list comprehensions in `statistics.py` and `data_exporter.py`
- Replace broad `except Exception: pass` with `except OSError: pass` in `airport_lookup.py` lock cleanup
- Use `logger.exception()` instead of `logger.error()` in parallel processing to preserve tracebacks
- Add Bandit security scanning job to CI workflow (medium+ severity)
- Suppress known-safe `B310` findings on hardcoded HTTPS URLs with `# nosec`